### PR TITLE
[MOSIP-722] -- TokenId generator used as a library in IDA

### DIFF
--- a/config-templates/id-authentication-env.properties
+++ b/config-templates/id-authentication-env.properties
@@ -200,6 +200,7 @@ rid-uin-auth.rest.uri=${mosip.base.url}/idrepository/v1/identity/rid/{rid}
 rid-uin-auth.rest.httpMethod=GET
 rid-uin-auth.rest.headers.mediaType=${mosip.ida.request.mediaType}
 rid-uin-auth.rest.timeout=${mosip.ida.request.timeout.secs}
+
 #VID-UIN-MAPPING#
 vid-service.vid-uin.rest.uri=${mosip.base.url}/idrepository/v1/vid/{vid}
 vid-service.vid-uin.rest.httpMethod=GET

--- a/config-templates/id-authentication-env.properties
+++ b/config-templates/id-authentication-env.properties
@@ -100,7 +100,11 @@ mosip.authentication.salt-generator.chunk-size=10
 #---------------------------------kernel Salt Generator---------------------------------------------------#
 mosip.kernel.salt-generator.db.key-alias=javax.persistence.jdbc
 mosip.kernel.salt-generator.schemaName=${javax.persistence.jdbc.schema}
-#----------------------------------------------------------------------------------------------------------#
+#--------------------------------TokenId generator---------------------------------------------------#
+mosip.kernel.tokenid.uin.salt=zHuDEAbmbxiUbUShgy6pwUhKh9DE0EZn9kQDKPPKbWscGajMwf
+mosip.kernel.tokenid.partnercode.salt=yS8w5Wb6vhIKdf1msi4LYTJks7mqkbmITk2O63Iq8h0bkRlD0d
+#----------------------------------------------------------------------------------------------------#
+
 
 # *********** REST-services *****************
 # Kernel-Audit

--- a/config-templates/id-authentication-env.properties
+++ b/config-templates/id-authentication-env.properties
@@ -220,12 +220,6 @@ id-masterdata-title-service.rest.httpMethod=GET
 id-masterdata-title-service.rest.headers.mediaType=${mosip.ida.request.mediaType}
 id-masterdata-title-service.rest.timeout=${mosip.ida.request.timeout.secs}
 
-# TokeId Generator rest api-GET
-token-id-generator.rest.uri=${mosip.base.url}/v1/tokenidgenerator/{uin}/{partnercode}
-token-id-generator.rest.httpMethod=GET
-token-id-generator.rest.headers.mediaType=${mosip.ida.request.mediaType}
-token-id-generator.rest.timeout=${mosip.ida.request.timeout.secs}
-
 #Auth token
 auth-token-generator.rest.uri=${mosip.base.url}/v1/authmanager/authenticate/clientidsecretkey
 auth-token-validator.rest.uri=${mosip.base.url}/v1/authmanager/authorize/validateToken

--- a/config-templates/id-repository-env.properties
+++ b/config-templates/id-repository-env.properties
@@ -17,6 +17,7 @@ mosip.idrepo.application.id=ID_REPO
 mosip.idrepo.application.name=ID-Repository
 mosip.idrepo.application.version.pattern=^v\\d+(\\.\\d+)?$
 mosip.idrepo.modulo-value=1000
+mosip.idrepo.datetime.future-time-adjustment=2
 
 #----------------------------------ID Repo Identity Service------------------------------------------------#
 mosip.idrepo.identity.application.version=v1


### PR DESCRIPTION
Kernel Token Id generator accessed as library instead of as Rest API.
So,following keys are removed
##TokeId Generator rest api-GET
token-id-generator.rest.uri=${mosip.base.url}/v1/tokenidgenerator/{uin}/{partnercode}
token-id-generator.rest.httpMethod=GET
token-id-generator.rest.headers.mediaType=${mosip.ida.request.mediaType}
token-id-generator.rest.timeout=${mosip.ida.request.timeout.secs}

And added following keys.

mosip.kernel.tokenid.uin.salt And mosip.kernel.tokenid.partnercode.salt