### PR TITLE
MOSIP-10416 : Cron expression properties corrected

### DIFF
--- a/sandbox/registration-processor-mz.properties
+++ b/sandbox/registration-processor-mz.properties
@@ -359,7 +359,7 @@ registration.processor.reprocess.seconds=*
 #schedular minutes configuration
 registration.processor.reprocess.minutes=*
 #schedular hours configuration
-registration.processor.reprocess.hours=24
+registration.processor.reprocess.hours=23
 #schedular days configuration
 registration.processor.reprocess.days_of_month=*
 #schedular months configuration


### PR DESCRIPTION
In cron expression, 24 is not valid for hour so the scheduler was not getting deployed and the container was going into crash loop. Now changed the hour to 23 and this should solve crash loop issue.