### PR TITLE
Biosdk service property removed as the same is being passed as

### DIFF
--- a/sandbox/id-authentication-mz.properties
+++ b/sandbox/id-authentication-mz.properties
@@ -96,10 +96,6 @@ ida.mapping.property.source=url:${mosip.ida.mapping.json-uri}
 # The fully qualified Class Name of the BIO SDK API implemented for Finger modality 
 # This class will be loaded in runtime, the containing jar should be available in classpath
 
-# mosip.biosdk.service will be used by biosdk-client to send the rest request to sdk services
-
-mosip.biosdk.service=http://13.233.66.241/biosdk-service/
-
 mosip.biometric.sdk.provider.finger.classname=io.mosip.biosdk.client.impl.Client
 # The version of the BIO SDK API implemeted for Finger modality
 mosip.biometric.sdk.provider.finger.version=0.9


### PR DESCRIPTION
env variable in dockers.