### PR TITLE
MOSIP-10521 : Proper kafka cluster bootstrap urls added and default event bus made to vertx

### DIFF
--- a/sandbox/registration-processor-dmz.properties
+++ b/sandbox/registration-processor-dmz.properties
@@ -115,11 +115,11 @@ mosip.auth.adapter.impl.basepackage=io.mosip.kernel.auth.defaultadapter
 
 #----------------------------------Event Bus------------------------------------------
 #Supported eventbus types: vertx, kafka. Defaults to vertx if the config is not given
-mosip.regproc.eventbus.type=kafka
+mosip.regproc.eventbus.type=vertx
 
 #Kafka event bus config, will be used only when the type is kafka
 #Kafka cluster servers comma separated, common for all stages and camel
-mosip.regproc.eventbus.kafka.bootstrap.servers=localhost:9092
+mosip.regproc.eventbus.kafka.bootstrap.servers=kafka-0.kafka-headless.default.svc.cluster.local:9092,kafka-1.kafka-headless.default.svc.cluster.local:9092,kafka-2.kafka-headless.default.svc.cluster.local:9092
 
 #packet-receiver-stage
 #Supported commmit config: auto, batch, single

--- a/sandbox/registration-processor-mz.properties
+++ b/sandbox/registration-processor-mz.properties
@@ -418,11 +418,11 @@ mosip.registration.processor.credential.request.service.id=mosip.credential.requ
 
 #----------------------------------Event Bus------------------------------------------
 #Supported eventbus types: vertx, kafka. Defaults to vertx if the config is not given
-mosip.regproc.eventbus.type=kafka
+mosip.regproc.eventbus.type=vertx
 
 #Kafka event bus config, will be used only when the type is kafka
 #Kafka cluster servers comma separated, common for all stages and camel
-mosip.regproc.eventbus.kafka.bootstrap.servers=localhost:9092
+mosip.regproc.eventbus.kafka.bootstrap.servers=kafka-0.kafka-headless.default.svc.cluster.local:9092,kafka-1.kafka-headless.default.svc.cluster.local:9092,kafka-2.kafka-headless.default.svc.cluster.local:9092
 
 #securezone-notification-stage
 #Supported commmit config: auto, batch, single


### PR DESCRIPTION
Proper kafka cluster bootstrap urls added and default event bus made to vertx