### PR TITLE
Revert "Added mosipbox_public_url for resident-service"

### DIFF
--- a/sandbox/resident-mz.properties
+++ b/sandbox/resident-mz.properties
@@ -40,7 +40,6 @@ token.request.issuerUrl=${mosip.keycloak.issuerUrl}
 
 #--------------URI--------------------------
 #Auth Services
-mosipbox.public.url=${mosipbox_public_url}
 KERNELAUTHMANAGER=http://kernel-auth-service/v1/authmanager/authenticate/clientidsecretkey
 REGPROCPRINT=http://regproc-print-service/registrationprocessor/v1/print/uincard
 INTERNALAUTH=http://ida-internal-service/idauthentication/v1/internal/auth


### PR DESCRIPTION
Reverts mosip/mosip-config#264

As per puneet this is taken care in the central files and not other properties should be introduced to overwrite the public URL. So reverting the change. 