### PR TITLE
MOSIP-11056 : Vid renewal feature replaced with Vid release to avoid guessing attacks

### DIFF
--- a/sandbox/kernel-mz.properties
+++ b/sandbox/kernel-mz.properties
@@ -100,8 +100,8 @@ mosip.kernel.tokenid.partnercode.salt=yS8w5Wb6vhIKdf1msi4LYTJks7mqkbmITk2O63Iq8h
 mosip.kernel.vid.min-unused-threshold=100000
 #number of vids to generate
 mosip.kernel.vid.vids-to-generate=200000
-#time to renew after expiry(in days)
-mosip.kernel.vid.time-to-renew-after-expiry=5
+#time to release after expiry(in days)
+mosip.kernel.vid.time-to-release-after-expiry=5
 #for genaration on init vids timeout 
 mosip.kernel.vid.pool-population-timeout=10000000
 


### PR DESCRIPTION
Config naming changed to adhere to the feature change