### PR TITLE
MOSIP-11192 : Validate URL config required for auth adapter in id generator service added

### DIFF
--- a/sandbox/kernel-mz.properties
+++ b/sandbox/kernel-mz.properties
@@ -336,6 +336,9 @@ kernel.uin.transfer-scheduler-days_of_month=*
 kernel.uin.transfer-scheduler-months=*
 kernel.uin.transfer-scheduler-days_of_week=*
 
+# UIN Auth adapter config
+auth.server.admin.validate.url=http://kernel-auth-service/v1/authmanager/authorize/admin/validateToken
+
 # Proxy otp
 mosip.kernel.auth.proxy-otp-value=111111
 mosip.security.provider.name=SunPKCS11-pkcs11-proxy


### PR DESCRIPTION
Validate URL config required for auth adapter in id generator service added