### PR TITLE
MOSIP-11072 : Key reference caching config added

### DIFF
--- a/sandbox/kernel-mz.properties
+++ b/sandbox/kernel-mz.properties
@@ -394,6 +394,9 @@ datastores=db_1_DS,db_2_DS
 
 mosip.kernel.keymanager.autogen.basekeys.list=RESIDENT:mpartner-default-resident
 
+# Keymanager service keystore cache properties
+mosip.kernel.keymanager.keystore.keyreference.enable.cache=true
+
 # API to get machine based on machine id
 mosip.kernel.syncdata-service-machine-url=http://kernel-masterdata-service/v1/masterdata/machines/%s/eng
 


### PR DESCRIPTION
This config is for keymanger to enable or disable key reference caching in keystore