### PR TITLE
MOSIP-11155 : MosipExceptionBiometrics tag generator is removed for now

### DIFF
--- a/sandbox/registration-processor-mz.properties
+++ b/sandbox/registration-processor-mz.properties
@@ -622,8 +622,8 @@ packetmanager.provider.uingenerator.proofOfException=source:CNIE\/process:CORREC
 
 # packet-classifier-stage
 # List of tag generator that should be run on every packet
-# Available tag generators MosipIDObjectFields,MosipMetaInfo,MosipAgeGroup,MosipSupervisorApprovalStatus,MosipExceptionBiometrics // DocumentMissing,MosipBiometricsMissing
-mosip.regproc.packet.classifier.tag-generators=MosipIDObjectFields,MosipMetaInfo,MosipAgeGroup,MosipSupervisorApprovalStatus,MosipExceptionBiometrics
+# Available tag generators MosipIDObjectFields,MosipMetaInfo,MosipAgeGroup,MosipSupervisorApprovalStatus
+mosip.regproc.packet.classifier.tag-generators=MosipIDObjectFields,MosipMetaInfo,MosipAgeGroup,MosipSupervisorApprovalStatus
 # These field names should be as in keys of registraion-processor-identity.json file Identity segment
 # and should have proper default source configured
 mosip.regproc.packet.classifier.tagging.idobjectfields.mapping-field-names=gender,city,residenceStatus


### PR DESCRIPTION
This is done since later exception information can be moved to the cbeff file