### PR TITLE
MOSIP-15124-lang change

### DIFF
--- a/sandbox/application-mz.properties
+++ b/sandbox/application-mz.properties
@@ -66,7 +66,7 @@ mosip.country.code=MOR
 # Language Supported By Platform - ISO 
 mosip.supported-languages=
 
-mosip.primary-language=
+mosip.primary-language=hin
 mosip.secondary-language=
 
 # Application IDs


### PR DESCRIPTION
Requested by PRe-reg as primary lang key is still used