### PR TITLE
Revert "[MOSIP-12752] updated idobjectvalidator properties"

### DIFF
--- a/sandbox/application-mz.properties
+++ b/sandbox/application-mz.properties
@@ -10,25 +10,37 @@ mosip.recommended.centers.locCode=5
 # Value used in IdObjectReferenceValidator when location is not available
 mosip.kernel.idobjectvalidator.masterdata.locations.locationNotAvailable=NA
 
-# Path to IDSchemaVersion. Path is defined as per JsonPath.compile.
-mosip.kernel.idobjectvalidator.identity.id-schema-version-path=identity.IDSchemaVersion
+# Masterdata apis used to retreive data for IdObjectReferenceValidator
+mosip.masterdata.base.url = http://kernel-masterdata-service.default:80
+mosip.syncdata.base.url=http://kernel-syncdata-service.default:80
+# commenting/removing below property will disable Gender masterdata validation
+#mosip.kernel.idobjectvalidator.masterdata.gendertypes.rest.uri=${mosip.masterdata.base.url}/v1/masterdata/gendertypes
 
-# Path to dateOfBirth field. Path is defined as per JsonPath.compile.
-mosip.kernel.idobjectvalidator.identity.dob-path = identity.dateOfBirth
+# commenting/removing below properties will disable Document Type masterdata validation
+mosip.kernel.idobjectvalidator.masterdata.documentcategories.rest.uri=${mosip.masterdata.base.url}/v1/masterdata/documentcategories
+mosip.kernel.idobjectvalidator.masterdata.documenttypes.rest.uri=${mosip.masterdata.base.url}/v1/masterdata/documenttypes/{documentcategorycode}/{langcode}
 
-# masterdata field data url
-mosip.idobjectvalidator.masterdata.rest.uri=${mosip.masterdata.base.url}/v1/masterdata/possiblevalues/{field}
+# commenting/removing below properties will disable location and location hierarchy masterdata validations
+mosip.kernel.idobjectvalidator.masterdata.locations.rest.uri=${mosip.masterdata.base.url}/v1/masterdata/locations/{langcode}
+mosip.kernel.idobjectvalidator.masterdata.locationhierarchy.rest.uri=${mosip.masterdata.base.url}/v1/masterdata/locations/locationhierarchy/{hierarchyname}
+
+# commenting/removing below properties will disable individualtype/resident status masterdata validations
+#mosip.kernel.idobjectvalidator.masterdata.individualtypes.rest.uri=${mosip.masterdata.base.url}/v1/masterdata/individualtypes
+
+# List of Location Hierarchy mappings for which the provided fields are from identity schema 
+# and its values are validated against mapped location hierarchy masterdata.
+# Needs to be updated when Identity Schema has been updated.
+mosip.kernel.idobjectvalidator.locationhierarchy.mapping.0=country
+mosip.kernel.idobjectvalidator.locationhierarchy.mapping.1=region
+mosip.kernel.idobjectvalidator.locationhierarchy.mapping.2=province
+mosip.kernel.idobjectvalidator.locationhierarchy.mapping.3=city
+mosip.kernel.idobjectvalidator.locationhierarchy.mapping.4=zone
+mosip.kernel.idobjectvalidator.locationhierarchy.mapping.5=postalCode
 
 # Date format expected in identity json. commenting/removing below property will disable dob format validation in identity json.
 mosip.kernel.idobjectvalidator.date-format=uuuu/MM/dd
 
-# IdObjectReferenceValidator scheduler cron job pattern to invoke cache reset
-mosip.idobjectvalidator.scheduler.reset-cache.cron-job-pattern=-
-
-# Refresh cache only once for a particular subType for each request, when a value is not found  for that subType. By default, it is false
-mosip.idobjectvalidator.refresh-cache-on-unknown-value=false
-
-# ---------------------------------- IdObjectValidator Properties ------------------------------------------#
+# --------- Properties that needs to be updated when Identity Schema has been updated ---------------#
 # Mandatory attributes used by IdObjectSchemaValidator. These values needs to be updated when Identity schema is updated.
 mosip.kernel.idobjectvalidator.mandatory-attributes.id-repository.new-registration=IDSchemaVersion,UIN,fullName,dateOfBirth|age,gender,addressLine1,region,province,city,zone
 mosip.kernel.idobjectvalidator.mandatory-attributes.id-repository.update-uin=IDSchemaVersion,UIN


### PR DESCRIPTION
Reverts mosip/mosip-config#588

Common properties were deleted mistakenly. 