### PR TITLE
Changed the name for salt table in regproc.

### DIFF
--- a/sandbox/registration-processor-mz.properties
+++ b/sandbox/registration-processor-mz.properties
@@ -309,7 +309,7 @@ mosip.kernel.salt-generator.start-sequence=0
 mosip.kernel.salt-generator.end-sequence=9999
 mosip.kernel.salt-generator.db.key-alias=mosip.regproc.db
 mosip.kernel.salt-generator.schemaName=regprc
-mosip.kernel.salt-generator.tableName=rid_encrypt_salt
+mosip.kernel.salt-generator.tableName=crypto_salt
 
 ####################################################################################################
 #------------------------------------ WORKFLOW ENGINE PROPERTIES -----------------------------------


### PR DESCRIPTION
 Changed the name for salt table in regproc.. It was pointing to old table name.