### PR TITLE
[ MOSIP-17992 ] updated kernel-default.properties

### DIFF
--- a/kernel-default.properties
+++ b/kernel-default.properties
@@ -434,7 +434,7 @@ mosip.ui.spec.default.domain=registration-client
 
 ## scheduler do it's job at 2am
 scheduling.job.cron=0 0 2 * * ?
-mosip.kernel.partner.issuer.certificate.allowed.grace.duration=200
+mosip.kernel.partner.issuer.certificate.allowed.grace.duration=30
 
 # masterdata swagger openApi
 openapi.masterdata.servers[0].url=http://masterdata.kernel/v1/masterdata


### PR DESCRIPTION
updated partner cert grace duration to 30 days
mosip.kernel.partner.issuer.certificate.allowed.grace.duration=30