### PR TITLE
MOSIP-18428(qa-double)

### DIFF
--- a/sandbox/partner-management-mz.properties
+++ b/sandbox/partner-management-mz.properties
@@ -222,7 +222,7 @@ pms.notifications-schedule.fixed-rate=24
 
 #Auth Adaptor
 #List of keycloack clients allowed to invoke pms APIs
-auth.server.admin.allowed.audience=mosip-creser-client,mosip-datsha-client,mosip-ida-client,mosip-regproc-client,mosip-admin-client,mosip-reg-client
+auth.server.admin.allowed.audience=mosip-creser-client,mosip-datsha-client,mosip-ida-client,mosip-regproc-client,mosip-admin-client,mosip-reg-client,mosip-resident-client
 
 ###############Not used properties###################
 pmp.policy.allowed.authtokens.types=random,partner,policy


### PR DESCRIPTION
Added "mosip-resident-client" to PMS auth adapter audience list