### PR TITLE
Revert "Signature verification disabled to allow processing of older packets"

### DIFF
--- a/sandbox/packet-manager-mz.properties
+++ b/sandbox/packet-manager-mz.properties
@@ -18,6 +18,3 @@ mosip.role.commons-packet.postdocument=DOCUMENT_READ
 mosip.role.commons-packet.postsearchfields=DATA_READ
 mosip.role.commons-packet.postsearchfield=DATA_READ
 auth.server.admin.allowed.audience=mosip-regproc-client
-
-# Performance testing changes
-packetmanager.packet.signature.disable-verification=true


### PR DESCRIPTION
Reverts mosip/mosip-config#1166