### PR TITLE
Update id-authentication-default.properties

### DIFF
--- a/id-authentication-default.properties
+++ b/id-authentication-default.properties
@@ -405,7 +405,7 @@ request.idtypes.allowed=VID,UIN
 request.idtypes.allowed.internalauth=UIN,VID
 
 ## Cryptograpic/Signature verificate related configurations
-mosip.ida.internal.thumbprint-validation-required=true
+mosip.ida.internal.thumbprint-validation-required=false
 mosip.ida.internal.trust-validation-required=false
 
 ## Kernel retry


### PR DESCRIPTION
Reverted back the changes mosip.ida.internal.thumbprint-validation-required=false