### PR TITLE
Update id-authentication-default.properties

### DIFF
--- a/id-authentication-default.properties
+++ b/id-authentication-default.properties
@@ -558,7 +558,7 @@ ida.fetch.failed.websub.messages.chunk.size=10
 #Auth Filters for external auth
 ida.mosip.external.auth.filter.classes.in.execution.order=io.mosip.authentication.hotlistfilter.impl.PartnerIdHotlistFilterImpl,io.mosip.authentication.hotlistfilter.impl.IndividualIdHotlistFilterImpl,io.mosip.authentication.hotlistfilter.impl.DeviceProviderHotlistFilterImpl,io.mosip.authentication.hotlistfilter.impl.DeviceHotlistFilterImpl,io.mosip.authentication.childauthfilter.impl.ChildAuthFilterImpl,io.mosip.authentication.authtypelockfilter.impl.AuthTypeLockFilterImpl
 #Auth Filters for kyc auth
-ida.mosip.internal.auth.filter.classes.in.execution.order=io.mosip.authentication.hotlistfilter.impl.IndividualIdHotlistFilterImpl,io.mosip.authentication.childauthfilter.impl.ChildAuthFilterImpl,io.mosip.authentication.authtypelockfilter.impl.AuthTypeLockFilterImpl
+ida.mosip.internal.auth.filter.classes.in.execution.order=io.mosip.authentication.hotlistfilter.impl.IndividualIdHotlistFilterImpl
 
 ## Demo SDK integration
 mosip.demographic.sdk.api.classname=io.mosip.demosdk.client.impl.spec_1_0.Client_V_1_0


### PR DESCRIPTION
removed io.mosip.authentication.childauthfilter.impl.ChildAuthFilterImpl, io.mosip.authentication.authtypelockfilter.impl.AuthTypeLockFilterImpl from ida.mosip.internal.auth.filter.classes.in.execution.order