### PR TITLE
Update id-authentication-default.properties

### DIFF
--- a/id-authentication-default.properties
+++ b/id-authentication-default.properties
@@ -545,7 +545,7 @@ cred-request-service-retrigger-cred-issuance.rest.timeout=${mosip.ida.request.ti
 
 # Child Auth Filter configurations
 ida.child-auth-filter.factors.denied=otp,bio
-ida.child-auth-filter.child.max.age=5
+ida.child-auth-filter.child.max.age=6
 
 # The chunk size of failed message items to be processed in spring batch. This value also assigned to the thread count, and hence all the items are processed in parellel asynchronusly.
 ida.fetch.failed.websub.messages.chunk.size=10


### PR DESCRIPTION
updated child max age to 6 years for testing in ida.child-auth-filter.child.max.age