### PR TITLE
Update print-default.properties

### DIFF
--- a/print-default.properties
+++ b/print-default.properties
@@ -134,3 +134,6 @@ mosip.print.crypto.p12.password={cipher}714cd7ff4c1aa550e7371fabcce089bf6411d697
 mosip.print.crypto.p12.alias=partner
 
 config.server.file.storage.uri=${spring.cloud.config.uri}/${spring.application.name}/${spring.profiles.active}/${spring.cloud.config.label}/
+
+# verifiable credential
+mosip.print.verify.credentials.flag=false


### PR DESCRIPTION
added new token related to verifiable credential as mosip.print.verify.credentials.flag=false