### PR TITLE
Update print-default.properties

### DIFF
--- a/print-default.properties
+++ b/print-default.properties
@@ -136,4 +136,4 @@ mosip.print.crypto.p12.alias=partner
 config.server.file.storage.uri=${spring.cloud.config.uri}/${spring.application.name}/${spring.profiles.active}/${spring.cloud.config.label}/
 
 # verifiable credential
-mosip.print.verify.credentials.flag=false
+mosip.print.verify.credentials.flag=true


### PR DESCRIPTION
update flag as true for  verifiable credential (mosip.print.verify.credentials.flag)