### PR TITLE
MOSIP-20214 : New configs added to make auditmanager work with direct…

### DIFF
--- a/kernel-default.properties
+++ b/kernel-default.properties
@@ -166,6 +166,13 @@ audit_database_url=jdbc:postgresql://${mosip.kernel.database.hostname}:${mosip.k
 audit_database_username=audituser
 audit_database_password=${db.dbuser.password}
 
+#Below db changes are related to Audit manager service since we are using direct JPA there instead of dataaccess library
+spring.datasource.driver-class-name=org.postgresql.Driver
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
+spring.jpa.hibernate.ddl-auto=none
+spring.jpa.properties.hibernate.jdbc.lob.non_contextual_creation=true
+spring.datasource.testWhileIdle=true
+spring.datasource.test-on-borrow=true
 
 masterdata_database_url=jdbc:postgresql://${mosip.kernel.database.hostname}:${mosip.kernel.database.port}/mosip_master
 masterdata_database_username=masteruser


### PR DESCRIPTION
… JPA instread of hibernate dataaccess library, this is done as part of performance fix to auditmanager. Backported from 1.1.5.6