### PR TITLE
Update application-default.properties

### DIFF
--- a/application-default.properties
+++ b/application-default.properties
@@ -269,7 +269,7 @@ mosip.kernel.prid.not-start-with=0,1
 mosip.kernel.prid.restricted-numbers=786,666
 
 ## VID
-mosip.kernel.vid.length=10
+mosip.kernel.vid.length=16
 # Upper bound of number of digits in sequence allowed in id. For example if
 # limit is 3, then 12 is allowed but 123 is not allowed in id (in both
 # ascending and descending order)


### PR DESCRIPTION
reverted the changes VID lenght 10 to 16 in mosip.kernel.vid.length