### PR TITLE
Update PMS allowed url(pms)

### DIFF
--- a/partner-management-default.properties
+++ b/partner-management-default.properties
@@ -161,7 +161,7 @@ policy.allowed.kyc.attributes = {"fullName": "Full Name","middleName": "Middle N
 policy.auth.allowed.token.types=random,partner,policy
 
 ## This property is used by kernel-authcodeflowproxy-api to check request is coming from allowed urls not.
-auth.allowed.urls=${mosip.api.internal.url}/pmp-ui/
+auth.allowed.urls=${mosip.api.internal.url}/pmp-ui/#/pmp/home
 
 # IAM
 mosip.iam.module.login_flow.name=authorization_code


### PR DESCRIPTION
Updated allowed url for pms UI as per the latest changes in authflowcode proxy library. 

[#MOSIP-20972](https://mosip.atlassian.net/browse/MOSIP-20972)