### PR TITLE
MOSIP-21493: Added mosip-toolkit-client as allowed audience for authmanager service - for Compliance Toolkit

### DIFF
--- a/kernel-default.properties
+++ b/kernel-default.properties
@@ -467,7 +467,7 @@ mosip.kernel.partner.issuer.certificate.allowed.grace.duration=365
 zone.user.details.url=${mosip.kernel-auth-service.url}/v1/authmanager/userdetails
 
 # list of comma seprated allowed audiences
-auth.server.admin.allowed.audience=mosip-regproc-client,mosip-prereg-client,mosip-admin-client,mosip-partner-client,mosip-crereq-client,mosip-creser-client,mosip-datsha-client,mosip-ida-client,mosip-resident-client,mosip-reg-client,mpartner-default-print,mosip-idrepo-client,mpartner-default-auth,mosip-syncdata-client,mosip-masterdata-client,mosip-idrepo-client,mosip-pms-client,mosip-hotlist-client
+auth.server.admin.allowed.audience=mosip-toolkit-client,mosip-regproc-client,mosip-prereg-client,mosip-admin-client,mosip-partner-client,mosip-crereq-client,mosip-creser-client,mosip-datsha-client,mosip-ida-client,mosip-resident-client,mosip-reg-client,mpartner-default-print,mosip-idrepo-client,mpartner-default-auth,mosip-syncdata-client,mosip-masterdata-client,mosip-idrepo-client,mosip-pms-client,mosip-hotlist-client
 
 # admin client credentials
 mosip.iam.adapter.appid=admin


### PR DESCRIPTION
MOSIP-21493: Added mosip-toolkit-client as allowed audience for authmanager service - for Compliance Toolkit