### PR TITLE
Update registration-processor-default.properties

### DIFF
--- a/registration-processor-default.properties
+++ b/registration-processor-default.properties
@@ -965,4 +965,4 @@ mosip.role.registration.getPostlostridsearch=REGISTRATION_ADMIN,REGISTRATION_OFF
 mosip.role.registration.getPostsync=REGISTRATION_ADMIN,REGISTRATION_PROCESSOR,REGISTRATION_OFFICER,REGISTRATION_SUPERVISOR,RESIDENT
 mosip.role.registration.getPostsyncv2=REGISTRATION_ADMIN,REGISTRATION_PROCESSOR,REGISTRATION_OFFICER,REGISTRATION_SUPERVISOR,RESIDENT
 auth.server.admin.allowed.audience=mosip-regproc-client,mosip-admin-client,mosip-resident-client,mosip-reg-client
-mosip.regproc.cbeff-validation.mandatory.modalities=Right,Left,Left RingFinger,Left LittleFinger,Right RingFinger,Left Thumb,Left IndexFinger,Right IndexFinger,Right LittleFinger,Right MiddleFinger,Left MiddleFinger,Right Thumb,Face,EXCEPTION_PHOTO
+mosip.regproc.cbeff-validation.mandatory.modalities=Right,Left,Left RingFinger,Left LittleFinger,Right RingFinger,Left Thumb,Left IndexFinger,Right IndexFinger,Right LittleFinger,Right MiddleFinger,Left MiddleFinger,Right Thumb,EXCEPTION_PHOTO


### PR DESCRIPTION
removed face from mosip.regproc.cbeff-validation.mandatory.modalities