### PR TITLE
Update kernel-default.properties

### DIFF
--- a/kernel-default.properties
+++ b/kernel-default.properties
@@ -440,7 +440,7 @@ mosip.service.end-points={cipher}dd5737cb38b0d354e925a031d1662cae45feb891135577d
 spring.jpa.properties.hibernate.jdbc.lob.non_contextual_creation=true
 
 ##validity time of mosip-signed certificates
-mosip.kernel.partner.issuer.certificate.duration.years=5
+
 
 ## Roles
 mosip.role.admin.masterdata.getapplicationconfigs=GLOBAL_ADMIN,ZONAL_ADMIN,PRE_REGISTRATION_ADMIN


### PR DESCRIPTION
Reverting back the changes done to add 5 years validity to mosip-signed certs