### PR TITLE
Updated otp.request.flooding.duration from 1 min to 20 mins in id-aut…

### DIFF
--- a/id-authentication-default.properties
+++ b/id-authentication-default.properties
@@ -328,7 +328,7 @@ ida.errormessages.default-lang=en
 
 ## OTP flooding
 ## Configure Time limit for OTP Flooding scenario (in minutes) 
-otp.request.flooding.duration=1
+otp.request.flooding.duration=20
 otp.request.flooding.max-count=100
 
 ## Notification templates


### PR DESCRIPTION
…hentication-default.properties

For executing Mimoto API's with a certain load for which requested otp duration needs to be increased.