### PR TITLE
Modified mosip.kernel.otp.expiry-time for application-default.properties

### DIFF
--- a/application-default.properties
+++ b/application-default.properties
@@ -248,7 +248,7 @@ mosip.kernel.otp.default-length=6
 ## Default crypto function: HmacSHA512, HmacSHA256, HmacSHA1.
 mosip.kernel.otp.mac-algorithm=HmacSHA512
 ## OTP expires after the given time (in seconds).
-mosip.kernel.otp.expiry-time=60
+mosip.kernel.otp.expiry-time=1800
 ## Key is frozen for the given time (in seconds).
 mosip.kernel.otp.key-freeze-time=1800
 ## Number of validation attempts allowed.


### PR DESCRIPTION
Modified mosip.kernel.otp.expiry-time for application-default.properties from 60 seconds to 1800 seconds for executing the request/otp mimoto api.