### PR TITLE
Reverting the modification for id-authentication-default.properties

### DIFF
--- a/id-authentication-default.properties
+++ b/id-authentication-default.properties
@@ -328,7 +328,7 @@ ida.errormessages.default-lang=en
 
 ## OTP flooding
 ## Configure Time limit for OTP Flooding scenario (in minutes) 
-otp.request.flooding.duration=20
+otp.request.flooding.duration=1
 otp.request.flooding.max-count=100
 
 ## Notification templates


### PR DESCRIPTION
Reverting the modification for id-authentication-default.properties made earlier for otp request flooding for 1 min.

Earlier PR --- https://github.com/mosip/mosip-config/pull/2893