### PR TITLE
Updated allowed file size

### DIFF
--- a/compliance-toolkit-default.properties
+++ b/compliance-toolkit-default.properties
@@ -172,6 +172,6 @@ mosip.toolkit.documentupload.allowed.file.type = application/zip
 # Determines the file name length(with extension) allowed in UI
 mosip.toolkit.documentupload.allowed.file.nameLength = 50
 # Determines maximum size of file allowed uploaded 10 MB
-mosip.toolkit.documentupload.allowed.file.size = 10000000
+mosip.toolkit.documentupload.allowed.file.size = 20000000
 
 mosip.toolkit.max.allowed.gallery.files=5


### PR DESCRIPTION
mosip.toolkit.documentupload.allowed.file.size = 20000000