### PR TITLE
Update registration-processor-mz.properties

### DIFF
--- a/sandbox/registration-processor-mz.properties
+++ b/sandbox/registration-processor-mz.properties
@@ -371,7 +371,7 @@ registration.processor.reprocess.fetchsize=500
 
 # The reprocessor scheduler configurations
 # The elapse time (in sec) beyond which the rids will be considered for reprocessing
-registration.processor.reprocess.elapse.time=1800
+registration.processor.reprocess.elapse.time=900
 # The maximum reprocess count. Beyond this the rid will not be considered for reprocessing.
 registration.processor.reprocess.attempt.count=300
 # Reprocess type
@@ -467,7 +467,7 @@ mosip.regproc.eventbus.kafka.bootstrap.servers=kafka-0.kafka-headless.default.sv
 
 #securezone-notification-stage
 #Supported commmit config: auto, batch, single
-mosip.regproc.securezone.notification.eventbus.kafka.commit.type=single
+mosip.regproc.securezone.notification.eventbus.kafka.commit.type=auto
 #Maximum records that can be received in one poll to kafka
 mosip.regproc.securezone.notification.eventbus.kafka.max.poll.records=100
 #Interval between each poll calls to kafka in milli sec
@@ -477,7 +477,7 @@ mosip.regproc.securezone.notification.eventbus.kafka.group.id=securezone-notific
 mosip.regproc.securezone.notification.message.expiry-time-limit=${mosip.regproc.common.stage.message.expiry-time-limit}
 
 #camel-bridge
-mosip.regproc.camel.bridge.eventbus.kafka.commit.type=single
+mosip.regproc.camel.bridge.eventbus.kafka.commit.type=auto
 mosip.regproc.camel.bridge.eventbus.kafka.max.poll.records=100
 mosip.regproc.camel.bridge.eventbus.kafka.poll.frequency=100
 #Above 3 camel kafka config will have no effect, it is kept because MosipBridgeFactory extends 
@@ -485,14 +485,14 @@ mosip.regproc.camel.bridge.eventbus.kafka.poll.frequency=100
 mosip.regproc.camel.bridge.eventbus.kafka.group.id=camel-brdige-mz
 
 #packet-uploader-stage
-mosip.regproc.packet.uploader.eventbus.kafka.commit.type=single
+mosip.regproc.packet.uploader.eventbus.kafka.commit.type=auto
 mosip.regproc.packet.uploader.eventbus.kafka.max.poll.records=5
 mosip.regproc.packet.uploader.eventbus.kafka.poll.frequency=500
 mosip.regproc.packet.uploader.eventbus.kafka.group.id=packet-uploader-stage
 mosip.regproc.packet.uploader.message.expiry-time-limit=${mosip.regproc.common.stage.message.expiry-time-limit}
 
 #packet-validator-stage
-mosip.regproc.packet.validator.eventbus.kafka.commit.type=batch
+mosip.regproc.packet.validator.eventbus.kafka.commit.type=auto
 #mosip.regproc.packet.validator.eventbus.kafka.max.poll.records=2
 mosip.regproc.packet.validator.eventbus.kafka.max.poll.records=4
 mosip.regproc.packet.validator.eventbus.kafka.poll.frequency=500
@@ -500,97 +500,97 @@ mosip.regproc.packet.validator.eventbus.kafka.group.id=packet-validator-stage
 mosip.regproc.packet.validator.message.expiry-time-limit=${mosip.regproc.common.stage.message.expiry-time-limit}
 
 #packet-classifier-stage
-mosip.regproc.packet.classifier.eventbus.kafka.commit.type=single
+mosip.regproc.packet.classifier.eventbus.kafka.commit.type=auto
 mosip.regproc.packet.classifier.eventbus.kafka.max.poll.records=10
 mosip.regproc.packet.classifier.eventbus.kafka.poll.frequency=100
 mosip.regproc.packet.classifier.eventbus.kafka.group.id=packet-classifier-stage
 mosip.regproc.packet.classifier.message.expiry-time-limit=${mosip.regproc.common.stage.message.expiry-time-limit}
 
 #quality-checker-stage
-mosip.regproc.quality.checker.eventbus.kafka.commit.type=single
+mosip.regproc.quality.checker.eventbus.kafka.commit.type=auto
 mosip.regproc.quality.checker.eventbus.kafka.max.poll.records=10
 mosip.regproc.quality.checker.eventbus.kafka.poll.frequency=100
 mosip.regproc.quality.checker.eventbus.kafka.group.id=quality-checker-stage
 mosip.regproc.quality.checker.message.expiry-time-limit=${mosip.regproc.common.stage.message.expiry-time-limit}
 
 #osi-validator-stage
-mosip.regproc.osi.validator.eventbus.kafka.commit.type=single
+mosip.regproc.osi.validator.eventbus.kafka.commit.type=auto
 mosip.regproc.osi.validator.eventbus.kafka.max.poll.records=10
 mosip.regproc.osi.validator.eventbus.kafka.poll.frequency=100
 mosip.regproc.osi.validator.eventbus.kafka.group.id=osi-validator-stage
 mosip.regproc.osi.validator.message.expiry-time-limit=${mosip.regproc.common.stage.message.expiry-time-limit}
 
 #external-stage
-mosip.regproc.external.eventbus.kafka.commit.type=single
+mosip.regproc.external.eventbus.kafka.commit.type=auto
 mosip.regproc.external.eventbus.kafka.max.poll.records=10
 mosip.regproc.external.eventbus.kafka.poll.frequency=100
 mosip.regproc.external.eventbus.kafka.group.id=external-stage
 mosip.regproc.external.message.expiry-time-limit=${mosip.regproc.common.stage.message.expiry-time-limit}
 
 #demo-dedupe-stage
-mosip.regproc.demo.dedupe.eventbus.kafka.commit.type=batch
+mosip.regproc.demo.dedupe.eventbus.kafka.commit.type=auto
 mosip.regproc.demo.dedupe.eventbus.kafka.max.poll.records=10
 mosip.regproc.demo.dedupe.eventbus.kafka.poll.frequency=1000
 mosip.regproc.demo.dedupe.eventbus.kafka.group.id=demo-dedupe-stage
 mosip.regproc.demo.dedupe.message.expiry-time-limit=${mosip.regproc.common.stage.message.expiry-time-limit}
 
 #abis-handler-stage
-mosip.regproc.abis.handler.eventbus.kafka.commit.type=single
+mosip.regproc.abis.handler.eventbus.kafka.commit.type=auto
 mosip.regproc.abis.handler.eventbus.kafka.max.poll.records=10
 mosip.regproc.abis.handler.eventbus.kafka.poll.frequency=100
 mosip.regproc.abis.handler.eventbus.kafka.group.id=abis-handler-stage
 mosip.regproc.abis.handler.message.expiry-time-limit=${mosip.regproc.common.stage.message.expiry-time-limit}
 
 #bio-dedupe-stage
-mosip.regproc.bio.dedupe.eventbus.kafka.commit.type=batch
+mosip.regproc.bio.dedupe.eventbus.kafka.commit.type=auto
 mosip.regproc.bio.dedupe.eventbus.kafka.max.poll.records=10
 mosip.regproc.bio.dedupe.eventbus.kafka.poll.frequency=100
 mosip.regproc.bio.dedupe.eventbus.kafka.group.id=bio-dedupe-stage
 mosip.regproc.bio.dedupe.message.expiry-time-limit=${mosip.regproc.common.stage.message.expiry-time-limit}
 
 #manual-verification-stage
-mosip.regproc.manual.verification.eventbus.kafka.commit.type=single
+mosip.regproc.manual.verification.eventbus.kafka.commit.type=auto
 mosip.regproc.manual.verification.eventbus.kafka.max.poll.records=10
 mosip.regproc.manual.verification.eventbus.kafka.poll.frequency=100
 mosip.regproc.manual.verification.eventbus.kafka.group.id=manual-verification-stage
 mosip.regproc.manual.verification.message.expiry-time-limit=${mosip.regproc.common.stage.message.expiry-time-limit}
 
 #uin-generator-stage
-mosip.regproc.uin.generator.eventbus.kafka.commit.type=batch
+mosip.regproc.uin.generator.eventbus.kafka.commit.type=auto
 mosip.regproc.uin.generator.eventbus.kafka.max.poll.records=3
 mosip.regproc.uin.generator.eventbus.kafka.poll.frequency=500
 mosip.regproc.uin.generator.eventbus.kafka.group.id=uin-generator-stage
 mosip.regproc.uin.generator.message.expiry-time-limit=${mosip.regproc.common.stage.message.expiry-time-limit}
 
 #abis-middle-ware-stage
-mosip.regproc.abis.middleware.eventbus.kafka.commit.type=single
+mosip.regproc.abis.middleware.eventbus.kafka.commit.type=auto
 mosip.regproc.abis.middleware.eventbus.kafka.max.poll.records=100
 mosip.regproc.abis.middleware.eventbus.kafka.poll.frequency=30000
 mosip.regproc.abis.middleware.eventbus.kafka.group.id=abis-middle-ware-stage
 mosip.regproc.abis.middleware.message.expiry-time-limit=${mosip.regproc.common.stage.message.expiry-time-limit}
 
 #biometric-authentication-stage
-mosip.regproc.biometric.authentication.eventbus.kafka.commit.type=single
+mosip.regproc.biometric.authentication.eventbus.kafka.commit.type=auto
 mosip.regproc.biometric.authentication.eventbus.kafka.max.poll.records=10
 mosip.regproc.biometric.authentication.eventbus.kafka.poll.frequency=100
 mosip.regproc.biometric.authentication.eventbus.kafka.group.id=biometric-authentication-stage
 mosip.regproc.biometric.authentication.message.expiry-time-limit=${mosip.regproc.common.stage.message.expiry-time-limit}
 
 #reprocessor-stage
-mosip.regproc.reprocessor.eventbus.kafka.commit.type=single
+mosip.regproc.reprocessor.eventbus.kafka.commit.type=auto
 mosip.regproc.reprocessor.eventbus.kafka.max.poll.records=100
 mosip.regproc.reprocessor.eventbus.kafka.poll.frequency=100
 mosip.regproc.reprocessor.eventbus.kafka.group.id=reprocessor-stage
 
 #message-sender-stage
-mosip.regproc.message.sender.eventbus.kafka.commit.type=single
+mosip.regproc.message.sender.eventbus.kafka.commit.type=auto
 mosip.regproc.message.sender.eventbus.kafka.max.poll.records=10
 mosip.regproc.message.sender.eventbus.kafka.poll.frequency=100
 mosip.regproc.message.sender.eventbus.kafka.group.id=message-sender-stage
 mosip.regproc.message.sender.message.expiry-time-limit=${mosip.regproc.common.stage.message.expiry-time-limit}
 
 #printing-stage
-mosip.regproc.printing.eventbus.kafka.commit.type=single  
+mosip.regproc.printing.eventbus.kafka.commit.type=auto  
 mosip.regproc.printing.eventbus.kafka.max.poll.records=5
 mosip.regproc.printing.eventbus.kafka.poll.frequency=100
 mosip.regproc.printing.eventbus.kafka.group.id=printing-stage
@@ -690,7 +690,7 @@ mosip.regproc.packet.classifier.tagging.exceptionbiometrics.bio-value-mapping={'
 # Based on value of below parameter the packets are passed or rejected. Required values are [APPROVED or REJECTED]
 mock.mv.decision=APPROVED 
 
-securezone.routing.enabled=true
+securezone.routing.enabled=false
 
 
 #-------------S3adapter-------------------


### PR DESCRIPTION
Kafka commit type changed to from single to auto for all reg proc stages and reprocessor time reduced from 30 min to 15 min 