### PR TITLE
Update registration-processor-mz.properties

### DIFF
--- a/sandbox/registration-processor-mz.properties
+++ b/sandbox/registration-processor-mz.properties
@@ -372,7 +372,7 @@ registration.processor.reprocess.fetchsize=500
 
 # The reprocessor scheduler configurations
 # The elapse time (in sec) beyond which the rids will be considered for reprocessing
-registration.processor.reprocess.elapse.time=900
+registration.processor.reprocess.elapse.time=300
 # The maximum reprocess count. Beyond this the rid will not be considered for reprocessing.
 registration.processor.reprocess.attempt.count=300
 # Reprocess type
@@ -712,4 +712,4 @@ registration.processor.verification.queue.url=${registration.processor.queue.url
 registration.processor.queue.manual.adjudication.request=mosip-to-mv
 registration.processor.queue.manual.adjudication.response=mv-to-mosip
 
-mosip.registration.processor.reprocessor.exclude-stage-names=''
+mosip.registration.processor.reprocessor.exclude-stage-names='dummy'


### PR DESCRIPTION
Reprocessor time decreased to 5 min and provided the dummy value for exclude stage 