### PR TITLE
Update application-default.properties

### DIFF
--- a/application-default.properties
+++ b/application-default.properties
@@ -252,7 +252,7 @@ mosip.kernel.otp.default-length=6
 ## Default crypto function: HmacSHA512, HmacSHA256, HmacSHA1.
 mosip.kernel.otp.mac-algorithm=HmacSHA512
 ## OTP expires after the given time (in seconds).
-mosip.kernel.otp.expiry-time=180
+mosip.kernel.otp.expiry-time=7200
 ## Key is frozen for the given time (in seconds).
 mosip.kernel.otp.key-freeze-time=1800
 ## Number of validation attempts allowed.


### PR DESCRIPTION
Updated the mosip.kernel.otp.expiry-time to 7200 from 180 seconds.