### PR TITLE
Updated mosip.idp.link-code-expire-in-secs=86400

### DIFF
--- a/idp-default.properties
+++ b/idp-default.properties
@@ -61,7 +61,7 @@ mosip.idp.access-token-expire-seconds=86400
 mosip.idp.id-token-expire-seconds=86400
 
 ## link transaction
-mosip.idp.link-code-expire-in-secs=60
+mosip.idp.link-code-expire-in-secs=86400
 mosip.idp.kafka.linked-session.topic=idp-linked
 mosip.idp.kafka.linked-auth-code.topic=idp-consented
 


### PR DESCRIPTION
For execution purpose updated the idp mosip.idp.link-code-expire-in-secs property.