### PR TITLE
Added MISP to allowed partner domains

### DIFF
--- a/kernel-default.properties
+++ b/kernel-default.properties
@@ -330,7 +330,7 @@ mosip.kernel.partner.sign.masterkey.application.id=PMS
 datastores=ldap_1_DS,db_1_DS,db_2_DS
 
 ## Partner Management Service allowed partner domains
-mosip.kernel.partner.allowed.domains=AUTH,DEVICE,FTM
+mosip.kernel.partner.allowed.domains=AUTH,DEVICE,FTM,MISP
 
 ## List of keys to auto generate.
 mosip.kernel.keymanager.autogen.appids.list=ROOT,KERNEL:SIGN,PRE_REGISTRATION,REGISTRATION,REGISTRATION_PROCESSOR,ID_REPO,KERNEL:IDENTITY_CACHE,RESIDENT,PMS,ADMIN_SERVICES


### PR DESCRIPTION
## Partner Management Service allowed partner domains mosip.kernel.partner.allowed.domains=AUTH,DEVICE,FTM,MISP