### PR TITLE
Enable CORS and allow access to mosip-toolkit-android-client

### DIFF
--- a/compliance-toolkit-default.properties
+++ b/compliance-toolkit-default.properties
@@ -36,8 +36,8 @@ server.servlet.context-path=/v1/toolkit
 
 ## Security properties
 mosip.security.csrf-enable=false
-mosip.security.cors-enable=false
-mosip.security.origins=localhost:8099
+mosip.security.cors-enable=true
+mosip.security.origins=http://localhost
 mosip.security.secure-cookie=false
 
 #iam
@@ -62,7 +62,7 @@ mosip.iam.adapter.clientid=mosip-toolkit-client
 mosip.iam.adapter.clientsecret=${mosip.toolkit.client.secret}
 
 auth.server.admin.issuer.uri=${keycloak.external.url}/auth/realms/
-auth.server.admin.allowed.audience=mosip-toolkit-client
+auth.server.admin.allowed.audience=mosip-toolkit-client,mosip-toolkit-android-client
 auth.allowed.urls=https://${mosip.compliance.host}/
 mosip.iam.certs_endpoint=${keycloak.external.url}/auth/realms/mosip/protocol/openid-connect/certs
 


### PR DESCRIPTION
Enable CORS and allow access to mosip-toolkit-android-client