### PR TITLE
Added mock ida integration properties

### DIFF
--- a/esignet-default.properties
+++ b/esignet-default.properties
@@ -122,14 +122,12 @@ mosip.esignet.authenticator.ida-env=Developer
 mosip.esignet.authenticator.ida.otp-channels=email,phone
 
 # Mock IDA integration props
-mosip.esignet.mock.authenticator.persona-repo=/home/mosip/mockida
-mosip.esignet.mock.authenticator.policy-repo=/home/mosip/mockida
-mosip.esignet.mock.authenticator.claims-mapping-file=/home/mosip/mockida/claims_attributes_mapping.json
 mosip.esignet.mock.authenticator.get-identity-url=https://${mosip.api.public.host}/v1/mock-identity-system/identity
 mosip.esignet.mock.authenticator.kyc-auth-url=https://${mosip.api.public.host}/v1/mock-identity-system/kyc-auth
 mosip.esignet.mock.authenticator.kyc-exchange-url=https://${mosip.api.public.host}/v1/mock-identity-system/kyc-exchange
 mosip.esignet.mock.authenticator.ida.otp-channels=${mosip.esignet.authenticator.ida.otp-channels}
 mosip.esignet.mock.authenticator.send-otp=https://${mosip.api.public.host}/v1/mock-identity-system/send-otp
+mosip.esignet.mock.supported.bind-auth-factor-types={'WLA'}
 
 ## ------------------------------------------ oauth & openid supported values ------------------------------------------
 


### PR DESCRIPTION
Added below properties under integration section for integrating Mock Authentication Service of esignet with mock-identity-system:

mosip.esignet.integration.scan-base-package=io.mosip.authentication.esignet.integration,io.mosip.esignet.mock.integration mosip.esignet.integration.binding-validator=BindingValidatorServiceImpl mosip.esignet.integration.authenticator=MockAuthenticationService mosip.esignet.integration.key-binder=MockKeyBindingWrapperService mosip.esignet.integration.audit-plugin=LoggerAuditService mosip.esignet.integration.captcha-validator=GoogleRecaptchaValidatorService

and commented below properties:
mosip.esignet.integration.scan-base-package=io.mosip.authentication.esignet.integration,io.mosip.esignet.mock.integration mosip.esignet.integration.binding-validator=BindingValidatorServiceImpl mosip.esignet.integration.authenticator=IdaAuthenticatorImpl mosip.esignet.integration.key-binder=IdaKeyBinderImpl #mosip.esignet.integration.key-binder=MockKeyBindingWrapperService mosip.esignet.integration.audit-plugin=IdaAuditPluginImpl mosip.esignet.integration.captcha-validator=GoogleRecaptchaValidatorService