### PR TITLE
Updated mosip-vid-policy.json property by increasing the vid instances for performance testing execution

### DIFF
--- a/mosip-vid-policy.json
+++ b/mosip-vid-policy.json
@@ -14,7 +14,7 @@
             "vidPolicy": {
                 "validForInMinutes": 30,
                 "transactionsAllowed": 1,
-                "instancesAllowed": 5,
+                "instancesAllowed": 1000,
                 "autoRestoreAllowed": false,
                 "restoreOnAction": "REGENERATE"
             }


### PR DESCRIPTION
For Performance Testing execution of **/residentmobileapp/vid mimoto api** increased the vid instances for a UIN from 5 to 1k.