### PR TITLE
Update application-default.properties

### DIFF
--- a/application-default.properties
+++ b/application-default.properties
@@ -439,8 +439,8 @@ openapi.service.servers[0].description=For Swagger
 mosip.auth.filter_disable=false
 
 # PDF Digital card is protected with password using below property based on define attribute it will encrypt by taking first 4 character.
-mosip.digitalcard.uincard.password=fullName|dateOfBirth
-mosip.digitalcard.pdf.password.enable.flag=false
+mosip.digitalcard.uincard.password=fullName
+mosip.digitalcard.pdf.password.enable.flag=true
 mosip.access_token.subject.claim-name=sub
 
 # It is used as a suffix for creating credential request ID using the RID.


### PR DESCRIPTION
 "mosip.digitalcard.uincard.password=fullName here removed  |dateOfBirth" and update "mosip.digitalcard.pdf.password.enable.flag=true" for testing purposes after testing I revert it back to default values. 