### PR TITLE
Update resident-default.properties

### DIFF
--- a/resident-default.properties
+++ b/resident-default.properties
@@ -211,10 +211,10 @@ mosip.id.validation.identity.phone=^([6-9]{1})([0-9]{9})$
 mosip.id.validation.identity.email=^[\\w-\\+]+(\\.[\\w]+)*@[\\w-]+(\\.[\\w]+)*(\\.[a-zA-Z]{2,})$
 
 #Validation properties
-resident.grievance-redressal.alt-email.chars.limit=128
-resident.grievance-redressal.alt-phone.chars.limit=64
-resident.grievance-redressal.comments.chars.limit=1024
-resident.share-credential.purpose.chars.limit=1024
+resident.grievance-redressal.alt-email.chars.limit=64
+resident.grievance-redressal.alt-phone.chars.limit=32
+resident.grievance-redressal.comments.chars.limit=512
+resident.share-credential.purpose.chars.limit=512
 mosip.resident.eventid.searchtext.length=16
 mosip.kernel.uin.length=10
 mosip.kernel.vid.length=16


### PR DESCRIPTION
Updated properties -resident.grievance-redressal.alt-email.chars.limit=128 to 64, resident.grievance-redressal.alt-phone.chars.limit=64 to 32, resident.grievance-redressal.comments.chars.limit=1024 to 512 and resident.share-credential.purpose.chars.limit=1024 to 512 for testing. After completed testing will be revert back to default value.