### PR TITLE
Update application-mz.properties

### DIFF
--- a/sandbox/application-mz.properties
+++ b/sandbox/application-mz.properties
@@ -287,7 +287,7 @@ mosip.kernel.otp.default-length=6
 #It can be: HmacSHA512, HmacSHA256, HmacSHA1.
 mosip.kernel.otp.mac-algorithm=HmacSHA512
 #the OTP expires after the given time(in seconds).
-mosip.kernel.otp.expiry-time=300
+mosip.kernel.otp.expiry-time=18000
 #the key is freezed for the given time(in seconds).
 mosip.kernel.otp.key-freeze-time=1800
 #the number of validation attempts allowed(in number).


### PR DESCRIPTION
Updating the mosip.kernel.otp.expiry-time=18000 for Performance Testing of Auth with OTP API.