### PR TITLE
Update instancesAllowed to 2 for Perpetual vid type

### DIFF
--- a/mosip-vid-policy.json
+++ b/mosip-vid-policy.json
@@ -4,7 +4,7 @@
             "vidPolicy": {
                 "validForInMinutes": null,
                 "transactionsAllowed": null,
-                "instancesAllowed": 1,
+                "instancesAllowed": 2,
                 "autoRestoreAllowed": true,
                 "restoreOnAction": "REVOKED"
             }


### PR DESCRIPTION
Updated 
"vidType": "Perpetual",
            "vidPolicy": {
                "validForInMinutes": null,
                "transactionsAllowed": null,
                "instancesAllowed": 2,
                "autoRestoreAllowed": true,
                "restoreOnAction": "REVOKED"