### PR TITLE
Update mosip-vid-policy.json

### DIFF
--- a/mosip-vid-policy.json
+++ b/mosip-vid-policy.json
@@ -4,16 +4,16 @@
             "vidPolicy": {
                 "validForInMinutes": null,
                 "transactionsAllowed": null,
-                "instancesAllowed": 2,
-                "autoRestoreAllowed": false,
-                "restoreOnAction": "REGENERATE"
+                "instancesAllowed": 1,
+                "autoRestoreAllowed": true,
+                "restoreOnAction": "REVOKED"
             }
         },
         {
             "vidType": "Temporary",
             "vidPolicy": {
-                "validForInMinutes": 30,
-                "transactionsAllowed": 1,
+                "validForInMinutes": null,
+                "transactionsAllowed": null,
                 "instancesAllowed": 20,
                 "autoRestoreAllowed": false,
                 "restoreOnAction": "REGENERATE"


### PR DESCRIPTION
Reverted back the changes for Perpetual and updated Temporary "vidType": "Temporary",
            "vidPolicy": {
                "validForInMinutes": null,
                "transactionsAllowed": null,
                "instancesAllowed": 20,
                "autoRestoreAllowed": false,
                "restoreOnAction": "REGENERATE"