### PR TITLE
Revert "Switch to external smtp url for testing."

### DIFF
--- a/kernel-default.properties
+++ b/kernel-default.properties
@@ -52,7 +52,7 @@ mosip.kernel.syncdata-service-idschema-url=${mosip.kernel.masterdata.url}/v1/mas
 mosip.kernel.sms.enabled:true
 mosip.kernel.sms.country.code: +91
 mosip.kernel.sms.number.length: 10
-mosip.kernel.sms.api:https://smtp.dev.mosip.net/sendsms
+mosip.kernel.sms.api:http://mock-smtp.mock-smtp:8080/sendsms
 mosip.kernel.sms.sender:AD-MOSIP
 mosip.kernel.sms.password:dummy
 mosip.kernel.sms.route:mock


### PR DESCRIPTION
Reverts mosip/mosip-config#4098