### PR TITLE
Updated the application-default.properties: mosip.left_to_right_orien…

### DIFF
--- a/application-default.properties
+++ b/application-default.properties
@@ -95,7 +95,7 @@ mosip.country.code=MOR
 ## Language supported by platform
 mosip.supported-languages=eng,ara,fra
 mosip.right_to_left_orientation=ara
-mosip.left_to_right_orientation=eng,ara
+mosip.left_to_right_orientation=eng,fra
 
 ## Application IDs
 mosip.prereg.app-id=PRE_REGISTRATION


### PR DESCRIPTION
…tation=eng,ara to eng,fra. Please merge this.

 ## Language supported by platform
 mosip.supported-languages=eng,ara,fra
 mosip.supported-languages=eng,ara,fra
 mosip.right_to_left_orientation=ara
 mosip.right_to_left_orientation=ara
mosip.left_to_right_orientation=eng,ara
mosip.left_to_right_orientation=eng,fra