### PR TITLE
[MOSIP-28019] Removed "mosip.kernel.virus-scanner.host" property from…

### DIFF
--- a/sandbox/registration-processor-mz.properties
+++ b/sandbox/registration-processor-mz.properties
@@ -266,8 +266,6 @@ registration.processor.id.repo.vidVersion=v1
 #---------Virus Scanner Stage---------
 #Virus scanner packet extension
 registration.processor.packet.ext=.zip
-#Virus scanner server host
-mosip.kernel.virus-scanner.host=clamav
 #Virus scanner port
 mosip.kernel.virus-scanner.port=80
 #Virus scanner application request id


### PR DESCRIPTION
… registration-processor-mz.properties.