### PR TITLE
Update esignet-default.properties

### DIFF
--- a/esignet-default.properties
+++ b/esignet-default.properties
@@ -31,8 +31,8 @@ mosip.esignet.misp.license.key=b22yVeZRRlk8RkMBzxBTvztYrZVYAuFyLkjJqWGlTwfPIlsRZ
 mosip.esignet.amr-acr-mapping-file-url=${spring_config_url_env}/*/${active_profile_env}/${spring_config_label_env}/amr-acr-mapping.json
 mosip.esignet.auth-txn-id-length=10
 mosip.esignet.supported-id-regex=\\S*
-mosip.esignet.id-token-expire-seconds=3600
-mosip.esignet.access-token-expire-seconds=3600
+mosip.esignet.id-token-expire-seconds=86400
+mosip.esignet.access-token-expire-seconds=86400
 mosip.esignet.link-code-expire-in-secs=60
 
 mosip.esignet.header-filter.paths-to-validate={'${server.servlet.path}/authorization/send-otp', \


### PR DESCRIPTION
Updating the below properties for Performance Testing: mosip.esignet.id-token-expire-seconds=86400
mosip.esignet.access-token-expire-seconds=86400