### PR TITLE
Update mosip-vid-policy.json

### DIFF
--- a/mosip-vid-policy.json
+++ b/mosip-vid-policy.json
@@ -13,7 +13,7 @@
             "vidType": "Temporary",
             "vidPolicy": {
                 "validForInMinutes": 30,
-                "transactionsAllowed": 5,
+                "transactionsAllowed": 1,
                 "instancesAllowed": 5,
                 "autoRestoreAllowed": false,
                 "restoreOnAction": "REGENERATE"
@@ -23,7 +23,7 @@
             "vidType": "OneTimeUse",
             "vidPolicy": {
                 "validForInMinutes": null,
-                "transactionsAllowed": 5,
+                "transactionsAllowed": 3,
                 "instancesAllowed": 4,
                 "autoRestoreAllowed": false,
                 "restoreOnAction": "REVOKED"


### PR DESCRIPTION
Changed  mosip-vid-policy.json, Temporary and OneTimeUse VID  "transationAllowed"=5 to Previous values 1 and 3 after testing completed.