### PR TITLE
MOSIP-29019 Update registration-processor-default.properties

### DIFF
--- a/registration-processor-default.properties
+++ b/registration-processor-default.properties
@@ -485,7 +485,7 @@ mosip.registration.processor.digitalcard.template=RPR_UIN_CARD_TEMPLATE
 mosip.registration.processor.print.template=RPR_UIN_CARD_TEMPLATE
 mosip.registration.processor.encrypt=false
 mosip.registration.processor.issuer=mpartner-default-print:${mosip.registration.processor.print.credentialtype}:${mosip.registration.processor.print.template};mpartner-default-digitalcard:${mosip.registration.processor.digitalcard.credentialtype}:${mosip.registration.processor.digitalcard.template}
- 
+CREDENTIALREQUESTV2=${mosip.idrepo.credrequest.generator.url}/v1/credentialrequest/v2/requestgenerator
 
 ## Stage common
 #After this time intervel, message should be considered as expired (In seconds), 


### PR DESCRIPTION
Updating the registration-processor-default.properties by adding CREDENTIALREQUESTV2=${mosip.idrepo.credrequest.generator.url}/v1/credentialrequest/v2/requestgenerator.