### PR TITLE
MOSIP-28993 Update resident-default.properties

### DIFF
--- a/resident-default.properties
+++ b/resident-default.properties
@@ -1002,3 +1002,4 @@ resident.date.time.formmatting.style=MEDIUM
 resident.date.time.replace.special.chars={" ": "_", "," : "", ":" : "."}
 #cache expiration time are in miliseconds.
 template.cache.expiry.time.millisec=86400000
+logging.level.io.mosip.resident.service.impl.ResidentVidServiceImpl=DEBUG


### PR DESCRIPTION
Updated resident-default.properties by adding
logging.level.io.mosip.resident.service.impl.ResidentVidServiceImpl=DEBUG.