### PR TITLE
Update registration-default.properties

### DIFF
--- a/registration-default.properties
+++ b/registration-default.properties
@@ -416,8 +416,8 @@ mosip.registration.mdm.RCAPTURE.connection.timeout=40000
 mosip.registration.mdm.MOSIPDINFO.connection.timeout=5000
 mosip.registration.mdm.MOSIPDISC.connection.timeout=5000
 
-mosip.registration.HTTP_API_READ_TIMEOUT=100
-mosip.registration.HTTP_API_WRITE_TIMEOUT=100
+mosip.registration.HTTP_API_READ_TIMEOUT=60000
+mosip.registration.HTTP_API_WRITE_TIMEOUT=60000
 
 ## Global properties
 mosip.right_to_left_orientation=${mosip.right_to_left_orientation}


### PR DESCRIPTION
Revert back to default value 6000 in mosip.registration.HTTP_API_READ_TIMEOUT and mosip.registration.HTTP_API_WRITE_TIMEOUT after completed the testing.