### PR TITLE
Update registration-processor-default.properties

### DIFF
--- a/registration-processor-default.properties
+++ b/registration-processor-default.properties
@@ -200,7 +200,7 @@ mosip.kernel.device.validate.history.id=""
 auth.PrependThumbprint.enable=false
 
 ## Packet receiver
-registration.processor.max.file.size=5
+registration.processor.max.file.size=2
 mosip.registration.processor.application.version=1.0
 mosip.registration.processor.datetime.pattern=yyyy-MM-dd'T'HH:mm:ss.SSS'Z'
 # Date pattern for registrationDate that should be followed in lostrid request


### PR DESCRIPTION
Changed registration.processor.max.file.size=5 to 2 for testing purposes, revert back to default value after testing completed