### PR TITLE
MOSIP-28989 Update id-authentication-default.properties

### DIFF
--- a/id-authentication-default.properties
+++ b/id-authentication-default.properties
@@ -624,6 +624,6 @@ mosip.role.keymanager.postjwtverify=INDIVIDUAL,ID_AUTHENTICATION,REGISTRATION_SU
 
 # Secret will be used during kyc token generation.
 mosip.ida.kyc.token.secret=${mosip.ida.kyc.token.secret}
-mosip.ida.kyc.token.expire.time.adjustment.seconds=3000
+mosip.ida.kyc.token.expire.time.adjustment.seconds=21600
 mosip.ida.kyc.exchange.default.lang=eng
 mosip.ida.idp.consented.address.subset.attributes=street_address,locality,region,postal_code,country


### PR DESCRIPTION
Updating the mosip.ida.kyc.token.expire.time.adjustment.seconds=3000 to 21600 seconds for the use of code in login redirect API for PT.