### PR TITLE
Remove VID from request.idtypes.allowed in id-authentication-default …

### DIFF
--- a/id-authentication-default.properties
+++ b/id-authentication-default.properties
@@ -361,7 +361,7 @@ ekyc.auth.types.allowed=demo,otp,bio-Finger,bio-Iris,bio-Face
 internal.auth.types.allowed=otp,bio-Finger,bio-Iris,bio-Face
 
 ## Allowed IdTypes for hotlisting
-mosip.ida.internal.hotlist.idtypes.allowed=UIN,VID,PARTNER_ID,DEVICE,DEVICE_PROVIDER
+mosip.ida.internal.hotlist.idtypes.allowed=UIN,PARTNER_ID,DEVICE,DEVICE_PROVIDER
 
 ## Datetime
 #Example allowed date time formats: "2020-10-23T12:21:38.660Z" , 2019-03-28T10:01:57.086+05:30
@@ -400,7 +400,7 @@ static.token.enable=true
 ## Allowed ID Types (allowed values : UIN/VID/USERID) to be supported for Authentication/KYC/OTP Requests
 request.idtypes.allowed=VID,UIN
 ## The ID types to be supported for Internal Authentication/OTP Requests
-request.idtypes.allowed.internalauth=UIN,VID
+request.idtypes.allowed.internalauth=UIN
 
 ## Cryptograpic/Signature verificate related configurations
 mosip.ida.internal.thumbprint-validation-required=false


### PR DESCRIPTION
…props

As VID service is not available in camdgc-dev env. Hence removing VID from "mosip.ida.internal.hotlist.idtypes.allowed" & "request.idtypes.allowed.internalauth"