### PR TITLE
Update registration-default.properties

### DIFF
--- a/registration-default.properties
+++ b/registration-default.properties
@@ -363,7 +363,7 @@ mosip.kernel.packetmanager.cbeff_only_unique_tags=Y
 mosip.registration.operator.onboarding.bioattributes=leftLittle,leftRing,leftMiddle,leftIndex,leftThumb,rightLittle,rightRing,rightMiddle,rightIndex,rightThumb,leftEye,rightEye,face
 
 #Check quality score of biometrics with SDK
-mosip.registration.quality_check_with_sdk=N
+mosip.registration.quality_check_with_sdk=Y
 
 #Replace MDS quality score of biometrics with SDK Quality Score
 mosip.registration.replace_sdk_quality_score=N


### PR DESCRIPTION
Changed mosip.registration.quality_check_with_sdk=N to Y for testing, revert back to default after testing completed.