### PR TITLE
Update esignet-default.properties

### DIFF
--- a/esignet-default.properties
+++ b/esignet-default.properties
@@ -34,7 +34,7 @@ mosip.esignet.supported-id-regex=\\S*
 mosip.esignet.id-token-expire-seconds=3600
 mosip.esignet.access-token-expire-seconds=3600
 mosip.esignet.link-code-expire-in-secs=600
-mosip.esignet.authentication-expire-in-secs=600
+mosip.esignet.authentication-expire-in-secs=120
 
 mosip.esignet.supported-pkce-methods={'S256'}
 
@@ -350,7 +350,7 @@ mosip.esignet.ui.config.key-values={'sbi.env': 'Developer', \
   'captcha.enable' : 'otp,pwd', \
   'auth.txnid.length' : '${mosip.esignet.auth-txn-id-length}',\
   'consent.screen.timeout-in-secs':${mosip.esignet.authentication-expire-in-secs}, \
-  'consent.screen.timeout-buffer-in-secs': 5,\
+  'consent.screen.timeout-buffer-in-secs': 10,\
   'linked-transaction-expire-in-secs': 120,\
   'sbi.port.range': 4501-4600, \
   'sbi.bio.subtypes.iris': 'UNKNOWN',\


### PR DESCRIPTION
Updated 'consent.screen.timeout-buffer-in-secs': 10 and  mosip.esignet.authentication-expire-in-secs=120