### PR TITLE
Update esignet-default.properties

### DIFF
--- a/esignet-default.properties
+++ b/esignet-default.properties
@@ -370,7 +370,7 @@ mosip.esignet.vci.authn.issuer-uri=${mosip.esignet.domain.url}${server.servlet.p
 mosip.esignet.vci.authn.jwk-set-uri=${mosip.esignet.domain.url}${server.servlet.path}/oauth/.well-known/jwks.json
 mosip.esignet.vci.authn.allowed-audiences={ '${mosip.esignet.domain.url}${server.servlet.path}/vci/credential' }
 
-mosip.esignet.cnonce-expire-seconds=40
+mosip.esignet.cnonce-expire-seconds=86400
 mosip.esignet.vci.supported.jwt-proof-alg={'RS256'}
 mosip.esignet.vci.key-values={ 'credential_issuer': '${mosip.esignet.domain.url}',         \
   'credential_endpoint': '${mosip.esignet.domain.url}${server.servlet.path}/vci/credential', \


### PR DESCRIPTION
Updating mosip.esignet.cnonce-expire-seconds=40 to 86400 tor Performance Testing Execution Purpose.