### PR TITLE
Update signup-default.properties

### DIFF
--- a/signup-default.properties
+++ b/signup-default.properties
@@ -1,7 +1,7 @@
 #----------------------------------------------------------------------------------------------------------------------------
 
 mosip.signup.id-schema.version=0.2
-mosip.signup.identifier.regex=^\\+855[1-4]\\d{5,12}$
+mosip.signup.identifier.regex=^^\\+855[1-9]\\d{7,8}$
 mosip.signup.identifier.prefix=+855
 mosip.signup.supported-languages={'khm','eng'}
 mosip.signup.password.pattern=^(?=.{8,20}$)(?=.*[A-Za-z])(?=.*\\d).*$


### PR DESCRIPTION
Reverted back the changes to mosip.signup.identifier.regex=^^\\+855[1-9]\\d{7,8}$