### PR TITLE
MOSIP-30990

### DIFF
--- a/digital-card-default.properties
+++ b/digital-card-default.properties
@@ -90,11 +90,6 @@ IDREPOGETIDBYUIN=${mosip.idrepo.identity.url}/idrepository/v1/identity/idvid
 # PDFSIGN to signed the pdf card
 PDFSIGN=${mosip.kernel.keymanager.url}/v1/keymanager/pdf/sign
 
-
-# PDF Digital card is protected with password using below property based on define attribute it will encrypt by taking first 4 character.
-mosip.digitalcard.uincard.password=fullName|dateOfBirth
-mosip.digitalcard.pdf.password.enable.flag=true
-
 #verifiable credential property that used to enable vc check.
 mosip.digitalcard.verify.credentials.flag=true
 


### PR DESCRIPTION
removed password property from digitalcard, its already there in application-default so removed duplicate properties.