### PR TITLE
ES-550 Update esignet-default.properties

### DIFF
--- a/esignet-default.properties
+++ b/esignet-default.properties
@@ -282,7 +282,7 @@ mosip.esignet.discovery.key-values={'issuer': '${mosip.esignet.domain.url}' ,\
   \ 'claims_parameter_supported' : true, \
   \ 'display_values_supported' : ${mosip.esignet.supported.ui.displays}, \
   \ 'subject_types_supported' : { 'pairwise' }, \
-  \ 'claims_supported' : {'name','address','gender','birthdate','picture','email','phone_number','individual_id','phone_number_verified','registration_type','updated_at'}, \
+  \ 'claims_supported' : {'name','address','gender','birthdate','picture','email','phone_number','individual_id'}, \
   \ 'claims_locales_supported' : {'en'}, \
   \ 'display_values_supported' : ${mosip.esignet.supported.ui.displays}, \
   \ 'ui_locales_supported' : {'en'} }


### PR DESCRIPTION
Updating the properties by removing 3 claims 
'phone_number_verified','registration_type','updated_at' as identity mapping json doesn't have these values.