### PR TITLE
ES-611 Update signup-default.properties

### DIFF
--- a/signup-default.properties
+++ b/signup-default.properties
@@ -21,7 +21,7 @@ mosip.signup.challenge.resend-delay=60
 ## Considering 5 minutes(300 seconds) to complete registration form and submit.
 ## Default status request limit is 10 with 20 seconds request delay, 10*20=200 seconds
 ## so 300+200=500 seconds is the authentication cookie max age.
-mosip.signup.register.txn.timeout=86400
+mosip.signup.verified.txn.timeout=86400
 mosip.signup.status-check.txn.timeout=86400
 mosip.signup.status.request.delay=20
 mosip.signup.status.request.limit=10


### PR DESCRIPTION
Replacing the mosip.signup.register.txn.timeout property name with mosip.signup.verified.txn.timeout acoording to latest build.