### PR TITLE
ES-550 Update id-authentication-default.properties

### DIFF
--- a/id-authentication-default.properties
+++ b/id-authentication-default.properties
@@ -619,7 +619,7 @@ mosip.role.keymanager.postjwtverify=INDIVIDUAL,ID_AUTHENTICATION,REGISTRATION_SU
 
 # Secret will be used during kyc token generation.
 mosip.ida.kyc.token.secret=${mosip.ida.kyc.token.secret}
-mosip.ida.kyc.token.expire.time.adjustment.seconds=3000
+mosip.ida.kyc.token.expire.time.adjustment.seconds=86400
 mosip.ida.kyc.exchange.default.lang=eng
 mosip.ida.idp.consented.address.subset.attributes=street_address,locality,region,postal_code,country
 


### PR DESCRIPTION
Updated the property kyc.token.expire.time.adjustment.seconds - 86400.