### PR TITLE
MOSIP-31188 Update id-authentication-default.properties

### DIFF
--- a/id-authentication-default.properties
+++ b/id-authentication-default.properties
@@ -506,7 +506,7 @@ mosip.kernel.keymanager.keystore.keyreference.enable.cache=false
 
 ## Admin
 # Configure N time period threshold for accepting auth/OTP/KYC request for a country
-authrequest.received-time-allowed.seconds=30
+authrequest.received-time-allowed.seconds=86400
 # Configuration for +/- time period adjustment in minutes for the request time validation, so that 
 # The requests originating from a system that is not in time-sync will be accepted for the time period
 authrequest.received-time-adjustment.seconds=30


### PR DESCRIPTION
Updating the time for mentioned property.
authrequest.received-time-allowed.seconds=30 to 86400 seconds i.e. 24hrs.