### PR TITLE
Update esignet-default.properties

### DIFF
--- a/sandbox/esignet-default.properties
+++ b/sandbox/esignet-default.properties
@@ -25,6 +25,17 @@
 # mosip.api.internal.url
 # mosip.api.public.url
 
+mosip.api.internal.url=${mosipbox.public.url}
+keycloak.external.url=${mosipbox.public.url}/keycloak
+keycloak.internal.url=http://keycloak.default:80
+mosip.api.public.host=${mosipbox.public.url}
+mosip.api.internal.host=${mosipbox.public.url}
+config.server.file.storage.uri=${spring.cloud.config.uri}/${spring.application.name}/${spring.profiles.active}/${spring.cloud.config.label}/
+mosip.esignet.host=${mosipbox.public.url}
+#mosip.esignet.misp.key=WC9egXBuXhqxl4bPZ7rr5AzoSNFgcB0vapVonPozkEC9Wed9EU
+mosip.kernel.otp.expiry-time=180
+
+
 
 ## ------------------------------------------------- e-Signet ----------------------------------------------------------
 mosip.esignet.misp.license.key=bmftkJ8LfUQE98eE1FWud68IwaflbqHXcf3px0SJHPxMcqMRP5


### PR DESCRIPTION
For error: Could not resolve placeholder 'mosip.api.public.host' in value \"https://${mosip.api.public.host}