### PR TITLE
Update id-authentication-default.properties

### DIFF
--- a/id-authentication-default.properties
+++ b/id-authentication-default.properties
@@ -649,13 +649,11 @@ mosip.ida.handle-types.regex={ '@phone' : '^\\+91[1-9][0-9]{7,9}@phone$' }
 
 #-------------------------------- Authentication error eventing-------------------------------
 #It enable and disable the bean init of kafka and Authentication error eventing
-mosip.ida.authentication.error.eventing.enabled=true
+mosip.ida.authentication.error.eventing.enabled=false
 #If we enable authentication error eventing as true we need all the below property
 ida-topic-authentication-error-eventing=AUTHENTICATION_ERRORS
 # Partner Id for encryption used in ondemand template extraction
 mosip.ida.authentication.error.eventing.encrypt.partner.id=mpartner-default-tempextraction
 #kafka Configuration
-mosip.ida.kafka.bootstrap.servers=kafka-0.kafka-headless.${kafka.profile}:${kafka.port},kafka-1.kafka-headless.${kafka.profile}:${kafka.port},kafka-2.kafka-headless.${kafka.profile}:${kafka.port}
-spring.kafka.admin.properties.allow.auto.create.topics=true
 logging.level.org.apache.kafka=DEBUG
 #----------------------------------------------------end------------------------------------------


### PR DESCRIPTION
Updated mosip.ida.authentication.error.eventing.enabled=false and removed below properties:
mosip.ida.kafka.bootstrap.servers=kafka-0.kafka-headless.${kafka.profile}:${kafka.port},kafka-1.kafka-headless.${kafka.profile}:${kafka.port},kafka-2.kafka-headless.${kafka.profile}:${kafka.port} spring.kafka.admin.properties.allow.auto.create.topics=true