### PR TITLE
PER-108 Update registration-processor-default.properties

### DIFF
--- a/registration-processor-default.properties
+++ b/registration-processor-default.properties
@@ -520,7 +520,7 @@ mosip.regproc.camel.bridge.eventbus.kafka.poll.frequency=100
 #MosipVerticleAPIManager
 mosip.regproc.camel.bridge.eventbus.kafka.group.id=camel-bridge
 mosip.regproc.camelbridge.endpoint-prefix=eventbus://
-mosip.regproc.camelbridge.pause-settings=[{"ruleId" :"PAUSE","matchExpression": "$.tags[?(@['AGE_GROUP'] == 'ADULT'&& @['ID_OBJECT-residenceStatus'] == 'Foreigner')]","pauseFor": 180,"defaultResumeAction": "RESUME_PROCESSING","fromAddress": "eventbus://packet-classifier-new-bus-out","ruleDescription" : "Non resident adult applicant packet"}],[{"ruleId" :"HOTLISTED_OPERATOR","matchExpression": "$.tags[?(@['HOTLISTED'] == 'operator')]","pauseFor": 432000,"defaultResumeAction": "STOP_PROCESSING","fromAddress": ".*","ruleDescription" : "Packet created by hotlisted operator"}]
+mosip.regproc.camelbridge.pause-settings=[{"ruleId" :"PAUSE","matchExpression": "$.tags[?(@['AGE_GROUP'] == 'ADULT'&& @['META_INFO-META_DATA-centerId'] == '10423')]","pauseFor": 180,"defaultResumeAction": "RESUME_PROCESSING","fromAddress": "eventbus://packet-classifier-new-bus-out","ruleDescription" : "Non resident adult applicant packet"}],[{"ruleId" :"HOTLISTED_OPERATOR","matchExpression": "$.tags[?(@['HOTLISTED'] == 'operator')]","pauseFor": 432000,"defaultResumeAction": "STOP_PROCESSING","fromAddress": ".*","ruleDescription" : "Packet created by hotlisted operator"}]
 ## Securzone stage (NOTE:  not used in V3, but need this for service to start)
 mosip.regproc.securezone.notification.eventbus.kafka.commit.type=single
 mosip.regproc.securezone.notification.eventbus.kafka.max.poll.records=100


### PR DESCRIPTION
Updated the property to pause the packets for one of the Workflow Action scenario testing.  Property updated "mosip.regproc.camelbridge.pause-settings" from 'ID_OBJECT-residenceStatus' == 'Foreigner' to 'META_INFO-META_DATA-centerId' == '10423.