### PR TITLE
[DSD-5364] bio challenge max length & linkedtransaction expiry time

### DIFF
--- a/esignet-default.properties
+++ b/esignet-default.properties
@@ -52,7 +52,7 @@ mosip.esignet.auth-challenge.PWD.max-length=30
 
 mosip.esignet.auth-challenge.BIO.format=encoded-json
 mosip.esignet.auth-challenge.BIO.min-length=5000
-mosip.esignet.auth-challenge.BIO.max-length=300000
+mosip.esignet.auth-challenge.BIO.max-length=400000
 
 mosip.esignet.auth-challenge.WLA.format=jwt
 mosip.esignet.auth-challenge.WLA.min-length=100
@@ -256,7 +256,7 @@ mosip.esignet.cache.expire-in-seconds={'clientdetails' : 86400, \
 'authcodegenerated': 60, \
 'userinfo': ${mosip.esignet.access-token-expire-seconds}, \
 'linkcodegenerated' : ${mosip.esignet.link-code-expire-in-secs}, \
-'linked': 120, \
+'linked': 300, \
 'linkedcode': ${mosip.esignet.link-code-expire-in-secs}, \
 'linkedauth' : ${mosip.esignet.authentication-expire-in-secs}, \
 'consented': 60, \


### PR DESCRIPTION
- change bio challenge max length from `3,00,000` to `4,00,000`
- change linked transaction expiry time from `120` to `300`