### PR TITLE
added mosip.ida.handle-types.regex

### DIFF
--- a/sandbox/id-authentication-default.properties
+++ b/sandbox/id-authentication-default.properties
@@ -637,6 +637,10 @@ mosip.kernel.keymgr.hsm.health.key.app-id=IDA
 #Flag to use if legacy salt selection method needs to be used for hashing the Individual ID. Default value is false if unspecified.
 mosip.ida.idhash.legacy-salt-selection-enabled=true
 
+# Regex to validate handles with provided key as the postfix
+# if the input handle is +855345353453@phone then the provided regex is used to validate the input.  
+mosip.ida.handle-types.regex={ '@phone' : '^\\+91[1-9][0-9]{7,9}@phone$' }
+
 #-------------------------------- Authentication error eventing-------------------------------
 #It enable and disable the bean init of kafka and Authentication error eventing
 mosip.ida.authentication.error.eventing.enabled=true


### PR DESCRIPTION
to test on demand template extraction for 1.2.1.0 IDA to avoid place holder issue