### PR TITLE
Update partner-management-mz.properties

### DIFF
--- a/sandbox/partner-management-mz.properties
+++ b/sandbox/partner-management-mz.properties
@@ -10,8 +10,8 @@
 ## Database
 ## Database hostname below is assuming postgres is running inside cluster in 'postgres' namespace
 ## If database is external to production, provide the DNS or ip of the host and port
-mosip.pmp.database.hostname=postgres-postgresql.postgres
-mosip.pmp.database.port=5432
+mosip.pmp.database.hostname=postgres
+mosip.pmp.database.port=80
 mosip.pmp.database.user=pmsuser
 mosip.pmp.database.password={cipher}6cbd7358f7a821132862475c16cf48e575c8e2c5f994fa7140ee08f364015b24
 


### PR DESCRIPTION
Changed from 
mosip.pmp.database.hostname=postgres-postgresql.postgres mosip.pmp.database.port=5432

to 
mosip.pmp.database.hostname=postgres
mosip.pmp.database.port=80

Wrongly changed By Kartki K