### PR TITLE
Update registration-processor-default.properties

### DIFF
--- a/registration-processor-default.properties
+++ b/registration-processor-default.properties
@@ -991,7 +991,7 @@ auth.server.admin.allowed.audience=mosip-regproc-client,mosip-admin-client,mosip
 mosip.regproc.cbeff-validation.mandatory.modalities=Right,Left,Left RingFinger,Left LittleFinger,Right RingFinger,Left Thumb,Left IndexFinger,Right IndexFinger,Right LittleFinger,Right MiddleFinger,Left MiddleFinger,Right Thumb,EXCEPTION_PHOTO
 
 mosip.regproc.landing.zone.account.name=landing-zone
-mosip.regproc.landing.zone.type=DMZServer
+mosip.regproc.landing.zone.type=ObjectStore
 mosip.regproc.landing.zone.fixed.delay.millisecs=120000
 mosip.regproc.landing.zone.inital.delay.millisecs=120000
 


### PR DESCRIPTION
reverting back  mosip.regproc.landing.zone.type to ObjectStore