### PR TITLE
Updating the id-repository-default.properties of camdgc-perf env.

### DIFF
--- a/id-repository-default.properties
+++ b/id-repository-default.properties
@@ -437,7 +437,7 @@ mosip.idrepo.identity.disable-uin-based-credential-request=false
 mosip.identity.fieldid.handle-postfix.mapping={'phone':'@phone'}
 
 #this property is very specific to the camdgc env 
-mosip.idrepo.vid.disable-support=true
+mosip.idrepo.vid.disable-support=false
 
 logging.level.io.mosip=DEBUG
 


### PR DESCRIPTION
Setting up the mosip.idrepo.vid.disable-support to false.

The purpose of the above action is to increase the number of records in mosip_ida table. We will creating the multiple VIDs in camdgc-perf environment. to mimick the production environment databases