### PR TITLE
Update certify-default.properties

### DIFF
--- a/certify-default.properties
+++ b/certify-default.properties
@@ -24,7 +24,7 @@ mosip.certify.discovery.issuer-id=${mosip.certify.domain.url}${server.servlet.pa
 
 mosip.certify.authn.filter-urls={ '${server.servlet.path}/issuance/credential', '${server.servlet.path}/issuance/vd11/credential', '${server.servlet.path}/issuance/vd12/credential' }
 
-mosip.certify.cnonce-expire-seconds=40
+mosip.certify.cnonce-expire-seconds=60
 
 # Change this if certify is used with different OAUTH2.0 server
 mosip.certify.authn.issuer-uri=${mosip.certify.authorization.url}/v1/esignet


### PR DESCRIPTION
updated mosip.certify.cnonce-expire-seconds=60 for testing