### PR TITLE
[PER-155] Updated the id-repository-default.properties

### DIFF
--- a/id-repository-default.properties
+++ b/id-repository-default.properties
@@ -434,7 +434,7 @@ mosip.mask.function.identityAttributes=convertToMaskData
 
 mosip.credential.service.fetch-identity.type=bio
 
-mosip.idrepo.credential.request.enable-convention-based-id=false
+mosip.idrepo.credential.request.enable-convention-based-id=true
 mosip.idrepo.credential-request-v2.rest.uri=${mosip.idrepo.credrequest.generator.url}/v1/credentialrequest/v2/requestgenerator/{rid}
 mosip.idrepo.credential-request-v2.rest.httpMethod=POST
 mosip.idrepo.credential-request-v2.rest.headers.mediaType=application/json


### PR DESCRIPTION
For convention-based request id for handles. By default, it is false. Now it has been changed to true for testing purpose

This property has been changed from false to true

#mosip.idrepo.credential.request.enable-convention-based-id=true