### PR TITLE
errorCode in kba field details

### DIFF
--- a/esignet-insurance.properties
+++ b/esignet-insurance.properties
@@ -423,7 +423,7 @@ mosip.esignet.ui.forgot-password.config={'forgot-password': true, 'forgot-passwo
 # form-details holds the list of field details like below:
 # id -> unique field Id, type -> holds datatype, format -> only supported for date fields, regex -> pattern to validate the input value, maxLength -> number of allowed characters
 # Example: mosip.esignet.authenticator.default.auth-factor.kba.field-details={{'id': '${mosip.esignet.authenticator.default.auth-factor.kba.individual-id-field}', 'type':'text', 'format':'', 'maxLength': 50, 'regex': '^\\s*[+-]?(\\d+|\\d*\\.\\d+|\\d+\\.\\d*)([Ee][+-]?\\d*)?\\s*$'},{'id':'fullName', 'type':'text', 'format':'', 'maxLength': 50, 'regex': '^[A-Za-z\\s]{1,}[\\.]{0,1}[A-Za-z\\s]{0,}$'},{'id':'dob', 'type':'date', 'format':'dd/mm/yyyy'}}
-mosip.esignet.authenticator.default.auth-factor.kba.field-details={{'id':'policyNumber', 'type':'text', 'format':'', 'maxLength': 50, 'regex': '^\\d+[-|\\d]+\\d+$'},{'id':'fullName', 'type':'text', 'format':'', 'maxLength': 50, 'regex': '[a-zA-Z]+(\\s+[a-zA-Z]+)*'},{"id":"dob", "type":"date"}}
+mosip.esignet.authenticator.default.auth-factor.kba.field-details={{'id':'policyNumber', 'type':'text', 'format':'', 'maxLength': 50, 'regex': '^\\d+[-|\\d]+\\d+$', 'errorCode': 'invalid_policy_number'},{'id':'fullName', 'type':'text', 'format':'', 'maxLength': 50, 'regex': '[a-zA-Z]+(\\s+[a-zA-Z]+)*', 'errorCode': 'invalid_full_name'},{"id":"dob", "type":"date"}}
 mosip.esignet.authenticator.default.auth-factor.kba.individual-id-field=policyNumber
 
 # username.prefix -> Prefix to be appended to the username, eg: if the username is phone_number then the prefix could be the country code


### PR DESCRIPTION
Added errorCode in kba form field

so that we can send `errorCode` to InputWithImage  component

`invalid_policy_number` for Policy Number
`invalid_full_name` for Full Name

both i18n code has been added in i18n bundle in `release-1.4.1-ES`