### PR TITLE
[MOSIP-34112] Update registration-processor-camel-routes-new-default.xml

### DIFF
--- a/registration-processor-camel-routes-new-default.xml
+++ b/registration-processor-camel-routes-new-default.xml
@@ -370,7 +370,8 @@
          </when>
          <when>
             <jsonpath suppressExceptions="true">$.[?(@['messageBusAddress']['address'] == 'manual-adjudication-bus-in')]</jsonpath>
-            <to uri="eventbus://manual-adjudication-bus-in" />
+		<to uri="workflow-cmd://complete-as-rejected" />
+            	<to uri="workflow-cmd://anonymous-profile" />
          </when>
          <otherwise>
             <to uri="eventbus://uin-generator-bus-in" />


### PR DESCRIPTION
[MOSIP-34112] when manual Adjudication is not present packet should go to failed state

[MOSIP-34112]: https://mosip.atlassian.net/browse/MOSIP-34112?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ