### PR TITLE
Increased the expiry time for ida-auth kyc to 24 hours in id-authentication-default.properties for cellbox1 environment

### DIFF
--- a/id-authentication-default.properties
+++ b/id-authentication-default.properties
@@ -629,7 +629,7 @@ mosip.role.keymanager.postjwtverify=INDIVIDUAL,ID_AUTHENTICATION,REGISTRATION_SU
 
 # Secret will be used during kyc token generation.
 mosip.ida.kyc.token.secret=${mosip.ida.kyc.token.secret}
-mosip.ida.kyc.token.expire.time.adjustment.seconds=3000
+mosip.ida.kyc.token.expire.time.adjustment.seconds=86400
 mosip.ida.kyc.exchange.default.lang=eng
 mosip.ida.idp.consented.address.subset.attributes=street_address,locality,region,postal_code,country
 mosip.kernel.keymgr.hsm.health.key.app-id=IDA


### PR DESCRIPTION
Increased the expiry time for ida-auth kyc to 24 hours in id-authentication-default.properties  in cellbox1 environment