### PR TITLE
Update application-default.properties

### DIFF
--- a/application-default.properties
+++ b/application-default.properties
@@ -442,7 +442,7 @@ openapi.service.servers[0].description=For Swagger
 mosip.auth.filter_disable=false
 
 # PDF Digital card is protected with password using below property based on define attribute it will encrypt by taking first 4 character.
-mosip.digitalcard.uincard.password=fullName|dateOfBirth
+mosip.digitalcard.uincard.password=firstName|dateOfBirth
 mosip.digitalcard.pdf.password.enable.flag=true
 
 # Comma separated values of allowed auth types


### PR DESCRIPTION
updated line 445 from fullName to mosip.digitalcard.uincard.password=firstName|dateOfBirth for resident testing