### PR TITLE
Updation in id-repository default property file for the faster movement of identities in identity cache table

### DIFF
--- a/id-repository-default.properties
+++ b/id-repository-default.properties
@@ -262,7 +262,7 @@ credential.request.token.request.clientId=${mosip.idrepo.credential-req-generato
 credential.request.token.request.secretKey=${mosip.idrepo.credential-req-generator.auth.secret-key}
 credential.request.token.request.version=1.0
 credential.request.token.request.id=io.mosip.credentialrequestgenerator
-credential.request.token.request.issuerUrl=${keycloak.internal.url}/auth/realms/mosip
+credential.request.token.request.issuerUrl=${keycloak.external.url}/auth/realms/mosip
 mosip.credential.request.service.id=mosip.credential.request.generator
 mosip.credential.request.datetime.pattern=yyyy-MM-dd'T'HH:mm:ss.SSS'Z'
 mosip.credential.request.service.version=1.0
@@ -272,13 +272,13 @@ mosip.credential.request.crypto-ref-id=credential_request
 
 	## Batch job
 # batch job time intervel in miliseconds
-mosip.credential.request.job.timedelay=3000
+mosip.credential.request.job.timedelay=1000
 #Reprocessing job timeintervel in miliseconds
 mosip.credential.request.reprocess.job.timedelay=1200000
 credential.request.type=auth
-credential.request.retry.max.count=10
+credential.request.retry.max.count=5
 credential.request.reprocess.statuscodes=FAILED,RETRY
-credential.batch.page.size=10
+credential.batch.page.size=500
 credential.request.process.locktimeout=60000
 credential.request.reprocess.locktimeout=60000
 credential.batch.status=NEW
@@ -442,7 +442,7 @@ mosip.idrepo.credential-request-v2.rest.timeout=100
 
 # It is recommended to not support UIN based authentication (both external & internal)
 # To stop issuing UIN+credential to IDA set flag to true otherwise set the flag to false to issue UIN+credential to IDA.
-mosip.idrepo.identity.disable-uin-based-credential-request=false
+mosip.idrepo.identity.disable-uin-based-credential-request=true
 # Field Id as in the identity schema will be the key and value is the actual postfix to append. Empty values are also supported.
 # This configuration is considered only when mentioned fieldId is marked to be a handle in the identity schema and it is one of the selectedHandle in the ID-object.
 mosip.identity.fieldid.handle-postfix.mapping={'phone':'@phone','email':'@email','functionalid':'@functionalid'}
@@ -453,3 +453,17 @@ mosip.idrepo.identity.max-request-time-deviation-seconds=60
 mosip.idrepo.create-identity.enable-force-merge=false
 mosip.identity.get.excluded.attribute.list=UIN,verifiedAttributes,IDSchemaVersion
 mosip.idrepo.update-identity.fields-to-replace={"selectedHandles","phone"}
+
+hikari.minimumIdle=10
+hikari.maximumPoolSize=50
+credential.batch.thread.count=100
+mosip.idrepo.identity-core-pool-size=50
+mosip.idrepo.identity-max-pool-size=100
+idrepo.default.processor.httpclient.connections.max.per.host=70
+idrepo.default.processor.httpclient.connections.max=500
+mosip.kernel.http.selftoken.restTemplate.max-connection-per-route=70
+mosip.kernel.http.selftoken.restTemplate.total-max-connections=500
+mosip.kernel.http.default.restTemplate.max-connection-per-route=70
+mosip.kernel.http.default.restTemplate.total-max-connections=500
+mosip.kernel.http.plain.restTemplate.max-connection-per-route=70
+mosip.kernel.http.plain.restTemplate.total-max-connections=500


### PR DESCRIPTION
Based on Vishwa's input, we have updated id-repo config file for the faster movement of identities in identity_cache table. The following changes are updated.

hikari.minimumIdle=10
hikari.maximumPoolSize=50
credential.request.token.request.issuerUrl=${keycloak.external.url}/auth/realms/mosip mosip.credential.request.job.timedelay=1000
credential.request.retry.max.count=5
credential.batch.page.size=500
credential.batch.thread.count=100
mosip.idrepo.identity-core-pool-size=50
mosip.idrepo.identity-max-pool-size=100
idrepo.default.processor.httpclient.connections.max.per.host=70
idrepo.default.processor.httpclient.connections.max=500 
mosip.kernel.http.selftoken.restTemplate.max-connection-per-route=70 
mosip.kernel.http.selftoken.restTemplate.total-max-connections=500 
mosip.kernel.http.default.restTemplate.max-connection-per-route=70 
mosip.kernel.http.default.restTemplate.total-max-connections=500 
mosip.kernel.http.plain.restTemplate.max-connection-per-route=70 
mosip.kernel.http.plain.restTemplate.total-max-connections=500 
mosip.idrepo.identity.disable-uin-based-credential-request=true