### PR TITLE
Updated signup-default.properties for cellbox1 environment 

### DIFF
--- a/signup-default.properties
+++ b/signup-default.properties
@@ -1,16 +1,16 @@
 #----------------------------------------------------------------------------------------------------------------------------
 # challenge.timeout, resend-delay are count as seconds
 mosip.signup.id-schema.version=0.4
-mosip.signup.identifier.regex=^\\+855[1-9]\\d{7,8}$
-mosip.signup.identifier.prefix=+855
-mosip.signup.supported-languages={'khm','eng'}
+mosip.signup.identifier.regex=^\\+91[0-9]\\d{8,9}$
+mosip.signup.identifier.prefix=+91
+mosip.signup.supported-languages={'eng'}
 mosip.signup.password.pattern=^(?=.*[0-9])(?=.*[a-z])(?=.*[A-Z])(?=.*[\\x5F\\W])(?=.{8,20})[a-zA-Z0-9\\x5F\\W]{8,20}$
 mosip.signup.password.max-length=20
 mosip.signup.generate-challenge.blocked.timeout=300
 mosip.signup.challenge.timeout=60
 mosip.signup.audit.description.max-length=2048
 mosip.signup.password.min-length=8
-mosip.signup.fullname.pattern=^[\\u1780-\\u17FF\\u19E0-\\u19FF\\u1A00-\\u1A9F\\u0020]{1,30}$
+mosip.signup.fullname.pattern=^[A-Za-z ]{1,30}$
 
 ## Time given to generate and verify the challenge in seconds.
 ## Default resend delay is 60 seconds, with 3 attempts, so 60*3=180 seconds.


### PR DESCRIPTION
The following changes are done.

mosip.signup.identifier.regex=^\\+91[0-9]\\d{8,9}$ 
mosip.signup.identifier.prefix=+91
mosip.signup.supported-languages={'eng'}

mosip.signup.fullname.pattern=^[A-Za-z ]{1,30}$