### PR TITLE
[PER-155] Update registration-processor-default.properties

### DIFF
--- a/registration-processor-default.properties
+++ b/registration-processor-default.properties
@@ -523,7 +523,7 @@ mosip.regproc.camelbridge.endpoint-prefix=eventbus://
 mosip.regproc.camelbridge.pause-settings=[{"ruleId" :"PAUSE","matchExpression": "$.tags[?(@['AGE_GROUP'] == 'ADULT'&& @['ID_OBJECT-residenceStatus'] == 'Foreigner')]","pauseFor": 180,"defaultResumeAction": "RESUME_PROCESSING","fromAddress": "eventbus://packet-classifier-new-bus-out","ruleDescription" : "Non resident adult applicant packet"}],[{"ruleId" :"HOTLISTED_OPERATOR","matchExpression": "$.tags[?(@['HOTLISTED'] == 'operator')]","pauseFor": 432000,"defaultResumeAction": "STOP_PROCESSING","fromAddress": ".*","ruleDescription" : "Packet created by hotlisted operator"}]
 ## Securzone stage (NOTE:  not used in V3, but need this for service to start)
 mosip.regproc.securezone.notification.eventbus.kafka.commit.type=single
-mosip.regproc.securezone.notification.eventbus.kafka.max.poll.records=100
+mosip.regproc.securezone.notification.eventbus.kafka.max.poll.records=10
 mosip.regproc.securezone.notification.eventbus.kafka.poll.frequency=100
 mosip.regproc.securezone.notification.eventbus.kafka.group.id=securezone-notification-stage
 mosip.regproc.securezone.notification.message.expiry-time-limit=${mosip.regproc.common.stage.message.expiry-time-limit}


### PR DESCRIPTION
Changing the property value from 100 to 10 for performance test mosip.regproc.securezone.notification.eventbus.kafka.max.poll.records=10