### PR TITLE
[injicert-434:farmer] make accessToken sub have individualId

### DIFF
--- a/mock-identity-system-mock.properties
+++ b/mock-identity-system-mock.properties
@@ -26,7 +26,8 @@
 # mosip.api.public.url
 
 ##----------------------------------------- Database properties --------------------------------------------------------
-
+# psut field in token should contain individualId for certify-mockdp-vci download w/o Redis dependency
+mosip.mock.ida.kyc.psut.field=individualId
 mosip.mockidentitysystem.database.hostname=postgres-postgresql.postgres
 mosip.mockidentitysystem.database.port=5432
 spring.datasource.url=jdbc:postgresql://${mosip.mockidentitysystem.database.hostname}:${mosip.mockidentitysystem.database.port}/mosip_mockidentitysystem?currentSchema=mockidentitysystem


### PR DESCRIPTION
Purpose:
* make eSignet-mock from dev1 return an accessToken w/ sub field having the individualId instead of PSUT.

Background:
* mock-identity-system feature PR ref: https://github.com/mosip/esignet-mock-services/pull/258/files

Breaks:
* current running inji-certify-mock which still expects psut field to have psut