### PR TITLE
[injicert-434:farmer] make accessToken sub have individualId (#7474)

### DIFF
--- a/mock-identity-system-default.properties
+++ b/mock-identity-system-default.properties
@@ -29,6 +29,7 @@
 
 mosip.mockidentitysystem.database.hostname=postgres-postgresql.postgres
 mosip.mockidentitysystem.database.port=5432
+mosip.mock.ida.kyc.psut.field=individualId
 spring.datasource.url=jdbc:postgresql://${mosip.mockidentitysystem.database.hostname}:${mosip.mockidentitysystem.database.port}/mosip_mockidentitysystem?currentSchema=mockidentitysystem
 spring.datasource.username=mockidsystemuser
 spring.datasource.password=${db.dbuser.password}


### PR DESCRIPTION
Purpose:
* make eSignet-mock from dev1 return an accessToken w/ sub field having the individualId instead of PSUT.

Background:
* mock-identity-system feature PR ref: https://github.com/mosip/esignet-mock-services/pull/258/files

Breaks:
* current running inji-certify-mock which still expects psut field to have psut