### PR TITLE
[DSD-6537]Update registration-processor-default.properties

### DIFF
--- a/registration-processor-default.properties
+++ b/registration-processor-default.properties
@@ -990,7 +990,7 @@ mosip.regproc.cbeff-validation.mandatory.modalities=Right,Left,Left RingFinger,L
 
 
 mosip.regproc.landing.zone.account.name=landing-zone
-mosip.regproc.landing.zone.type=DMZServer
+mosip.regproc.landing.zone.type=ObjectStore
 mosip.regproc.landing.zone.fixed.delay.millisecs=120000
 mosip.regproc.landing.zone.inital.delay.millisecs=120000
 


### PR DESCRIPTION
changing mosip.regproc.landing.zone.type from DMZServer to ObjectStore