### PR TITLE
Update signup-default.properties with the latest changes for cellbox1 enviroment

### DIFF
--- a/signup-default.properties
+++ b/signup-default.properties
@@ -4,6 +4,7 @@ mosip.signup.id-schema.version=0.4
 mosip.signup.identifier.regex=^\\+91[0-9]\\d{8,9}$
 mosip.signup.identifier.prefix=+91
 mosip.signup.supported-languages={'eng','khm'}
+mosip.signup.default-language=khm
 mosip.signup.password.pattern=^(?=.*[0-9])(?=.*[a-z])(?=.*[A-Z])(?=.*[\\x5F\\W])(?=.{8,20})[a-zA-Z0-9\\x5F\\W]{8,20}$
 mosip.signup.password.max-length=20
 mosip.signup.generate-challenge.blocked.timeout=300
@@ -19,6 +20,7 @@ mosip.signup.fullname.pattern=^[A-Za-z ]{1,30}$
 ## so 250 seconds is the Generate and verify cookie max age.
 mosip.signup.unauthenticated.txn.timeout=250
 mosip.signup.challenge.resend-attempt=3
+mosip.signup.challenge.verification-attempt=3
 mosip.signup.challenge.resend-delay=${mosip.signup.challenge.timeout}
 
 ## Time given to complete registration and get back the status of the registration in seconds.
@@ -29,31 +31,71 @@ mosip.signup.verified.txn.timeout=300
 mosip.signup.status-check.txn.timeout=200
 mosip.signup.status.request.delay=20
 mosip.signup.status.request.limit=10
+mosip.signup.status.request.retry-error-codes=unknown_error
+
+## Thread pool size
+mosip.signup.task.core.pool.size=2
+mosip.signup.task.max.pool.size=4
+
+mosip.signup.domain.url=https://${mosip.signup.host}
+mosip.esignet.domain.url=https://${mosip.esignet.host}
+
+## Idenity verification configurations
+mosip.signup.config-server-url=classpath:
+mosip.signup.identity-verification.txn.timeout=180
+mosip.signup.oauth.client-id=mosip-signup-oauth-client
+mosip.signup.oauth.redirect-uri=${mosip.signup.domain.url}/identity-verification
+mosip.signup.oauth.issuer-uri=${mosip.esignet.domain.url}
+mosip.signup.oauth.keystore-path=keys/oidckeystore.p12
+mosip.signup.oauth.keystore-password=${mosip.signup.oidc.keystore.pwd}
+mosip.signup.oauth.key-alias=mosip-signup-oauth-client
+mosip.signup.oauth.audience=${mosip.esignet.domain.url}/v1/esignet/oauth/v2/token
+mosip.signup.oauth.token-uri=http://esignet.esignet/v1/esignet/oauth/v2/token
+mosip.signup.oauth.userinfo-uri=http://esignet.esignet/v1/esignet/oidc/userinfo
+
+mosip.signup.slot.max-count=50
+mosip.signup.slot.request.delay=20
+mosip.signup.slot.request.limit=10
+mosip.signup.slot.expire-in-seconds=3600
+mosip.signup.slot.cleanup-cron=0 0 * * * *
+
+mosip.signup.slot-allotted.timeout=1000
+mosip.signup.verified-slot.timeout=1000
 
 ## ------------------------------------- challenge configuration -------------------------------------------------------
 
 mosip.signup.supported.generate-challenge-type=OTP
 mosip.signup.supported.challenge-format-types={'alpha-numeric', 'base64url-encoded-json'}
-mosip.signup.supported.challenge-types={'OTP', 'KBA'}
+mosip.signup.supported.challenge-types={'OTP', 'KBI'}
 mosip.signup.supported.challenge.otp.length=6
 
 ## ------------------------------------- Cache configuration -----------------------------------------------------------
 mosip.signup.cache.symmetric-algorithm-name=AES/CFB/PKCS5Padding
+
+# Use 'simple' for in-memory cache in non-production env
 spring.cache.type=simple
 
-#spring.cache.type=redis
-#spring.cache.cache-names=${mosip.esignet.cache.names}
-#spring.redis.host=localhost
-#spring.redis.port=6379
+spring.cache.type=redis
+spring.cache.cache-names=${mosip.esignet.cache.names}
+spring.redis.host=${redis.host}
+spring.redis.port=${redis.port}
+spring.redis.password=${redis.password}
 management.health.redis.enabled=false
 
-mosip.esignet.cache.names=challenge_generated,challenge_verified,status_check,blocked_identifier,keystore,key_alias
+mosip.esignet.cache.names=challenge_generated,challenge_verified,status_check,blocked_identifier,keystore,key_alias,request_ids,identity_verification,identity_verifiers,idv_metadata,slot_allotted,verified_slot,slots_connected
 mosip.esignet.cache.size={'challenge_generated': 200, \
   'challenge_verified': 200,\
   'status_check': 200,\
   'blocked_identifier':2000,\
   'keystore' : 10, \
-  'key_alias' : 2 }
+  'key_alias' : 2,\
+  'request_ids' : 300,\
+  'identity_verification': 200,\
+  'identity_verifiers' : 20, \
+   'idv_metadata' : 30,\
+  'slot_allotted' : 200, \
+  'slots_connected': 200,\
+  'verified_slot' : 200 } 
 
 ## Note: keystore TTL should be more than the key_alias cache TTL.
 ## So that key rotation happens before the actual key is removed from the keystore cache.
@@ -62,15 +104,22 @@ mosip.esignet.cache.expire-in-seconds={'challenge_generated': ${mosip.signup.una
   'status_check': ${mosip.signup.status-check.txn.timeout}, \
   'blocked_identifier': ${mosip.signup.generate-challenge.blocked.timeout},\
   'keystore' : 600, \
-  'key_alias' : 300 }
+  'key_alias' : 300,\
+  'request_ids' : ${mosip.signup.status-check.txn.timeout},\
+  'identity_verification' : ${mosip.signup.identity-verification.txn.timeout},\
+  'identity_verifiers' : 800, \
+  'idv_metadata' : 500,\
+  'slot_allotted' : ${mosip.signup.slot-allotted.timeout}, \
+  'slots_connected': 1000,\
+  'verified_slot' : ${mosip.signup.verified-slot.timeout} }
 
 ## ------------------------------------- Auth adapter ------------------------------------------------------------------
 
-auth.server.validate.url=${mosip.kernel.authmanager.url}/v1/authmanager/authorize/admin/validateToken
+auth.server.validate.url=http://authmanager.kernel/v1/authmanager/authorize/admin/validateToken
 auth.server.admin.issuer.uri=${keycloak.external.url}/auth/realms/
 auth-token-generator.rest.issuerUrl=${keycloak.internal.url}/auth/realms/mosip
 mosip.keycloak.issuerUrl=${keycloak.internal.url}/auth/realms/mosip
-mosip.auth.adapter.impl.basepackage=io.mosip.kernel.auth.defaultadapter
+#mosip.auth.adapter.impl.basepackage=io.mosip.kernel.auth.defaultadapter
 mosip.kernel.auth.adapter.ssl-bypass=true
 mosip.kernel.auth.appid-realm-map={admin:'mosip',crereq:'mosip',creser:'mosip',idrepo:'mosip', signup:'mosip'}
 mosip.kernel.auth.appids.realm.map={admin:'mosip',crereq:'mosip',creser:'mosip',idrepo:'mosip','regproc':'mosip', signup:'mosip'}
@@ -94,32 +143,39 @@ mosip.security.cors-enable=true
 ## -------------------------- External endpoints -----------------------------------------------------------------------
 
 mosip.signup.generate-challenge.endpoint=http://otpmanager.kernel/v1/otpmanager/otp/generate
-mosip.signup.get-identity.endpoint=http://identity.idrepo/idrepository/v1/identity/idvid/%s@phone?type=demo&idType=HANDLE
-mosip.signup.identity.endpoint=http://identity.idrepo/idrepository/v1/identity/
-mosip.signup.generate-hash.endpoint=http://keymanager.keymanager/v1/keymanager/generateArgon2Hash
-mosip.signup.get-uin.endpoint=http://idgenerator.kernel/v1/idgenerator/uin
+#mosip.signup.get-identity.endpoint=http://identity.idrepo/idrepository/v1/identity/idvid/%s@phone?type=demo&idType=HANDLE
+#mosip.signup.identity.endpoint=http://identity.idrepo/idrepository/v1/identity/
+#mosip.signup.generate-hash.endpoint=http://keymanager.keymanager/v1/keymanager/generateArgon2Hash
+#mosip.signup.get-uin.endpoint=http://idgenerator.kernel/v1/idgenerator/uin
 mosip.signup.send-notification.endpoint=http://notifier.kernel/v1/notifier/sms/send
-mosip.signup.get-registration-status.endpoint=http://credentialrequest.idrepo/v1/credentialrequest/get/{applicationId}
+#mosip.signup.get-registration-status.endpoint=http://credentialrequest.idrepo/v1/credentialrequest/get/{applicationId}
 mosip.signup.audit-endpoint=http://auditmanager.kernel/v1/auditmanager/audits
-mosip.signup.add-identity.request.id=mosip.id.create
-mosip.signup.update-identity.request.id=mosip.id.update
-mosip.signup.identity.request.version=v1
+#mosip.signup.add-identity.request.id=mosip.id.create
+#mosip.signup.update-identity.request.id=mosip.id.update
+#mosip.signup.identity.request.version=v1
 
 ## --------------------------------- captcha validator------------------------------------------------------------------
 mosip.signup.send-challenge.captcha-required=false
-mosip.signup.integration.captcha-validator=GoogleRecaptchaValidatorService
-mosip.signup.captcha-validator.url=https://www.google.com/recaptcha/api/siteverify
-mosip.signup.captcha-validator.site-key=${signup.captcha.site.key}
-mosip.signup.captcha-validator.secret=${signup.captcha.secret.key}
+#mosip.signup.integration.captcha-validator=GoogleRecaptchaValidatorService
+#mosip.signup.captcha-validator.url=https://www.google.com/recaptcha/api/siteverify
+mosip.esignet.captcha.module-name=signup
+mosip.esignet.captcha.validator-url=http://captcha.captcha/v1/captcha/validatecaptcha
+mosip.signup.captcha.site-key=${signup.captcha.site.key}
+#mosip.signup.captcha-validator.secret=${signup.captcha.secret.key}
 
 ## ----------------------------- UI-Config -----------------------------------------------------------------------------
 
+mosip.signup.minimum-browser-version={ \
+  'chrome': '118.0.6423.142', \
+  'firefox': '126.1.1', \
+  'edge': '118.0.2535.93', \
+  'safari': '16.1' }
 # Only after current challenge timeout we should enable resend in the UI.
 # In this case timeout and resend-delay should be same always.
 mosip.signup.ui.config.key-values={\
 'identifier.pattern': '${mosip.signup.identifier.regex}', \
 'identifier.prefix': '${mosip.signup.identifier.prefix}', \
-'captcha.site.key': '${mosip.signup.captcha-validator.site-key}', \
+'captcha.site.key': '${mosip.signup.captcha.site-key}', \
 'otp.length': ${mosip.signup.supported.challenge.otp.length}, \
 'password.pattern': '${mosip.signup.password.pattern}', \
 'password.length.max': ${mosip.signup.password.max-length}, \
@@ -130,26 +186,42 @@ mosip.signup.ui.config.key-values={\
 'fullname.pattern': '${mosip.signup.fullname.pattern}', \
 'status.request.delay': ${mosip.signup.status.request.delay}, \
 'status.request.limit': ${mosip.signup.status.request.limit}, \
+'status.request.retry.error.codes': '${mosip.signup.status.request.retry-error-codes}', \
+'slot.request.delay': ${mosip.signup.slot.request.delay}, \
+'slot.request.limit': ${mosip.signup.slot.request.limit}, \
 'popup.timeout': 10, \
-'signin.redirect-url': 'https://${mosip.esignet.host}/authorize', \
+'signin.redirect-url': '${mosip.esignet.domain.url}/authorize', \
 'identifier.allowed.characters': '^[0-9]+', \
 'identifier.length.min': 8, \
 'identifier.length.max': 9, \
-'fullname.allowed.characters': '^[\\u1780-\\u17FF\\u19E0-\\u19FF\\u1A00-\\u1A9F\\u0020]', \
+'fullname.allowed.characters': '[^\\u1780-\\u17FF\\u19E0-\\u19FF\\u1A00-\\u1A9F\\u0020]', \
 'fullname.length.min': 1, \
 'fullname.length.max': 30, \
-'otp.blocked' : ${mosip.signup.generate-challenge.blocked.timeout} \
+'otp.blocked' : ${mosip.signup.generate-challenge.blocked.timeout}, \
+'send-challenge.captcha.required': ${mosip.signup.send-challenge.captcha-required}, \
+'signup.oauth-client-id': '${mosip.signup.oauth.client-id}', \
+'identity-verification.redirect-url': '${mosip.signup.oauth.redirect-uri}', \
+'broswer.minimum-version': ${mosip.signup.minimum-browser-version}, \
+'esignet-consent.redirect-url': '${mosip.esignet.domain.url}/consent' 
 }
 
 ## ----------------------------- SMS-message -----------------------------------------------------------------------------
 
 # Default charset encoding ISO-8859-1 does not support khmer language characters, so templates in khm language are base64 encoded.
+mosip.signup.sms-notification-template.encoded-langcodes={'khm'}
 mosip.signup.sms-notification-template.send-otp.khm=4Z6U4Z+S4Z6a4Z6+IHtjaGFsbGVuZ2V9IOGeiuGevuGemOGfkuGelOGeuOGeleGfkuGekeGfgOGehOGeleGfkuGekeGetuGej+Gfi+GeguGejuGek+GeuCBLaElEIOGemuGelOGen+Gfi+GeouGfkuGek+GegOGflA==
 mosip.signup.sms-notification-template.send-otp.eng=Use {challenge} to verify your KhID account.
 mosip.signup.sms-notification-template.registration.khm=4Z6i4Z+S4Z6T4Z6A4Z6U4Z624Z6T4Z6F4Z674Z+H4Z6I4Z+S4Z6Y4Z+E4Z+H4Z6C4Z6O4Z6T4Z64IEtoSUQg4Z6K4Z+E4Z6Z4Z6H4Z+E4Z6C4Z6H4Z+Q4Z6Z4Z+U
 mosip.signup.sms-notification-template.registration.eng=You successfully registered to KhID account.
 mosip.signup.sms-notification-template.forgot-password.khm=4Z6i4Z+S4Z6T4Z6A4Z6U4Z624Z6T4Z6V4Z+S4Z6b4Z624Z6f4Z+L4Z6U4Z+S4Z6K4Z684Z6a4Z6W4Z624Z6A4Z+S4Z6Z4Z6f4Z6Y4Z+S4Z6E4Z624Z6P4Z+LIEtoSUQg4Z6K4Z+E4Z6Z4Z6H4Z+E4Z6C4Z6H4Z+Q4Z6Z4Z+U
 mosip.signup.sms-notification-template.forgot-password.eng=You successfully changed KhID password.
+
+## Kafka configurations
+kafka.profile=kafka.svc.cluster.local
+kafka.port=9092
+kafka.bootstrap-servers=kafka-0.kafka-headless.${kafka.profile}:${kafka.port},kafka-1.kafka-headless.${kafka.profile}:${kafka.port},kafka-2.kafka-headless.${kafka.profile}:${kafka.port}
+kafka.consumer.group-id=signup-idv-kafka
+kafka.consumer.enable-auto-commit=true
 
 #------------------------------------------ Others ---------------------------------------------------------------------
 logging.level.io.mosip.signup=INFO


### PR DESCRIPTION
The following config changes are updated and added. mosip.signup.default-language=khm
mosip.signup.challenge.verification-attempt=3
mosip.signup.status.request.retry-error-codes=unknown_error

## Thread pool size
mosip.signup.task.core.pool.size=2
mosip.signup.task.max.pool.size=4

mosip.signup.domain.url=https://${mosip.signup.host} mosip.esignet.domain.url=https://${mosip.esignet.host}

## Idenity verification configurations
mosip.signup.config-server-url=classpath:
mosip.signup.identity-verification.txn.timeout=180 mosip.signup.oauth.client-id=mosip-signup-oauth-client mosip.signup.oauth.redirect-uri=${mosip.signup.domain.url}/identity-verification mosip.signup.oauth.issuer-uri=${mosip.esignet.domain.url} mosip.signup.oauth.keystore-path=keys/oidckeystore.p12 mosip.signup.oauth.keystore-password=${mosip.signup.oidc.keystore.pwd} mosip.signup.oauth.key-alias=mosip-signup-oauth-client mosip.signup.oauth.audience=${mosip.esignet.domain.url}/v1/esignet/oauth/v2/token mosip.signup.oauth.token-uri=http://esignet.esignet/v1/esignet/oauth/v2/token mosip.signup.oauth.userinfo-uri=http://esignet.esignet/v1/esignet/oidc/userinfo

mosip.signup.slot.max-count=50
mosip.signup.slot.request.delay=20
mosip.signup.slot.request.limit=10
mosip.signup.slot.expire-in-seconds=3600
mosip.signup.slot.cleanup-cron=0 0 * * * *

mosip.signup.slot-allotted.timeout=1000
mosip.signup.verified-slot.timeout=1000

mosip.signup.supported.challenge-types={'OTP', 'KBI'} spring.cache.type=redis
spring.cache.cache-names=${mosip.esignet.cache.names} spring.redis.host=${redis.host}
spring.redis.port=${redis.port}
spring.redis.password=${redis.password}
mosip.esignet.cache.names=challenge_generated,challenge_verified,status_check,blocked_identifier,keystore,key_alias,request_ids,identity_verification,identity_verifiers,idv_metadata,slot_allotted,verified_slot,slots_connected

mosip.esignet.cache.size={'challenge_generated': 200, \
  'challenge_verified': 200,\
  'status_check': 200,\
  'blocked_identifier':2000,\
  'keystore' : 10, \
  'key_alias' : 2,\
  'request_ids' : 300,\
  'identity_verification': 200,\
  'identity_verifiers' : 20, \
   'idv_metadata' : 30,\
  'slot_allotted' : 200, \
  'slots_connected': 200,\
  'verified_slot' : 200 }
mosip.esignet.cache.expire-in-seconds={'challenge_generated': ${mosip.signup.unauthenticated.txn.timeout},\
  'challenge_verified': ${mosip.signup.verified.txn.timeout},\
  'status_check': ${mosip.signup.status-check.txn.timeout}, \
  'blocked_identifier': ${mosip.signup.generate-challenge.blocked.timeout},\
  'keystore' : 600, \
  'key_alias' : 300,\
  'request_ids' : ${mosip.signup.status-check.txn.timeout},\
  'identity_verification' : ${mosip.signup.identity-verification.txn.timeout},\
  'identity_verifiers' : 800, \
  'idv_metadata' : 500,\
  'slot_allotted' : ${mosip.signup.slot-allotted.timeout}, \
  'slots_connected': 1000,\
  'verified_slot' : ${mosip.signup.verified-slot.timeout} }
auth.server.validate.url=http://authmanager.kernel/v1/authmanager/authorize/admin/validateToken mosip.esignet.captcha.module-name=signup
mosip.esignet.captcha.validator-url=http://captcha.captcha/v1/captcha/validatecaptcha mosip.signup.minimum-browser-version={ \
  'chrome': '118.0.6423.142', \
  'firefox': '126.1.1', \
  'edge': '118.0.2535.93', \
  'safari': '16.1' }
mosip.signup.ui.config.key-values={\
'identifier.pattern': '${mosip.signup.identifier.regex}', \ 'identifier.prefix': '${mosip.signup.identifier.prefix}', \ 'captcha.site.key': '${mosip.signup.captcha.site-key}', \ 'otp.length': ${mosip.signup.supported.challenge.otp.length}, \ 'password.pattern': '${mosip.signup.password.pattern}', \ 'password.length.max': ${mosip.signup.password.max-length}, \ 'password.length.min': ${mosip.signup.password.min-length}, \ 'challenge.timeout': ${mosip.signup.challenge.resend-delay}, \ 'resend.attempts': ${mosip.signup.challenge.resend-attempt}, \ 'resend.delay': ${mosip.signup.challenge.resend-delay}, \ 'fullname.pattern': '${mosip.signup.fullname.pattern}', \ 'status.request.delay': ${mosip.signup.status.request.delay}, \ 'status.request.limit': ${mosip.signup.status.request.limit}, \ 'status.request.retry.error.codes': '${mosip.signup.status.request.retry-error-codes}', \ 'slot.request.delay': ${mosip.signup.slot.request.delay}, \ 'slot.request.limit': ${mosip.signup.slot.request.limit}, \ 'popup.timeout': 10, \
'signin.redirect-url': '${mosip.esignet.domain.url}/authorize', \ 'identifier.allowed.characters': '^[0-9]+', \
'identifier.length.min': 8, \
'identifier.length.max': 9, \
'fullname.allowed.characters': '[^\\u1780-\\u17FF\\u19E0-\\u19FF\\u1A00-\\u1A9F\\u0020]', \ 'fullname.length.min': 1, \
'fullname.length.max': 30, \
'otp.blocked' : ${mosip.signup.generate-challenge.blocked.timeout}, \ 'send-challenge.captcha.required': ${mosip.signup.send-challenge.captcha-required}, \ 'signup.oauth-client-id': '${mosip.signup.oauth.client-id}', \ 'identity-verification.redirect-url': '${mosip.signup.oauth.redirect-uri}', \ 'broswer.minimum-version': ${mosip.signup.minimum-browser-version}, \ 'esignet-consent.redirect-url': '${mosip.esignet.domain.url}/consent' } mosip.signup.sms-notification-template.encoded-langcodes={'khm'}

## Kafka configurations
kafka.profile=kafka.svc.cluster.local
kafka.port=9092
kafka.bootstrap-servers=kafka-0.kafka-headless.${kafka.profile}:${kafka.port},kafka-1.kafka-headless.${kafka.profile}:${kafka.port},kafka-2.kafka-headless.${kafka.profile}:${kafka.port} kafka.consumer.group-id=signup-idv-kafka
kafka.consumer.enable-auto-commit=true