### PR TITLE
Update signup-default.properties with additional fields

### DIFF
--- a/signup-default.properties
+++ b/signup-default.properties
@@ -1,1 +1,6 @@
 mosip.signup.idrepo.mandatory-language=eng
+mosip.signup.identifier.regex=^\\+91[0-9]\\d{8,9}$
+mosip.signup.identifier.prefix=+91
+mosip.signup.supported-languages={'eng'}
+mosip.signup.default-language=eng
+mosip.signup.fullname.pattern=.*


### PR DESCRIPTION
mosip.signup.identifier.regex=^\\+91[0-9]\\d{8,9}$ mosip.signup.identifier.prefix=+91
mosip.signup.supported-languages={'eng'}
mosip.signup.default-language=eng
mosip.signup.fullname.pattern=.*