### PR TITLE
set the mock-identity-system config for workshop

### DIFF
--- a/mock-identity-system-default.properties
+++ b/mock-identity-system-default.properties
@@ -29,6 +29,7 @@
 
 mosip.mockidentitysystem.database.hostname=postgres-postgresql.postgres
 mosip.mockidentitysystem.database.port=5432
+mosip.mock.ida.kyc.psut.field=individualId
 spring.datasource.url=jdbc:postgresql://${mosip.mockidentitysystem.database.hostname}:${mosip.mockidentitysystem.database.port}/mosip_mockidentitysystem?currentSchema=mockidentitysystem
 spring.datasource.username=mockidsystemuser
 spring.datasource.password=${db.dbuser.password}


### PR DESCRIPTION
This is required for the Friday's Inji workshop as the DB plugin requires the individualId in the `sub` field of the accessToken.