### PR TITLE
[PER-194]: Update esignet-default.properties for disabling auth token for eSignet client ID generation

### DIFF
--- a/esignet-default.properties
+++ b/esignet-default.properties
@@ -92,12 +92,18 @@ mosip.esignet.binding.encrypt-binding-id=false
 
 ## -------------------------------------- Authentication & Authorization -----------------------------------------------
 
-mosip.esignet.security.auth.post-urls={'${server.servlet.path}/client-mgmt/**' : {'SCOPE_add_oidc_client'} , \
-  \ '${server.servlet.path}/system-info/**' : { 'SCOPE_upload_certificate'},\
-  \ '${server.servlet.path}/binding/wallet-binding' : { 'SCOPE_wallet_binding'}, \
-  \ '${server.servlet.path}/binding/binding-otp' : { 'SCOPE_send_binding_otp'}}
-mosip.esignet.security.auth.put-urls={'${server.servlet.path}/client-mgmt/**' : { 'SCOPE_update_oidc_client'} }
-mosip.esignet.security.auth.get-urls={'${server.servlet.path}/system-info/**' : { 'SCOPE_get_certificate'} }
+#mosip.esignet.security.auth.post-urls={'${server.servlet.path}/client-mgmt/**' : {'SCOPE_add_oidc_client'} , \
+#  \ '${server.servlet.path}/system-info/**' : { 'SCOPE_upload_certificate'},\
+#  \ '${server.servlet.path}/binding/wallet-binding' : { 'SCOPE_wallet_binding'}, \
+#  \ '${server.servlet.path}/binding/binding-otp' : { 'SCOPE_send_binding_otp'}}
+#mosip.esignet.security.auth.put-urls={'${server.servlet.path}/client-mgmt/**' : { 'SCOPE_update_oidc_client'} }
+#mosip.esignet.security.auth.get-urls={'${server.servlet.path}/system-info/**' : { 'SCOPE_get_certificate'} }
+
+#Disabling auth factors for Client ID generation eSignet Mock identity service
+mosip.esignet.security.auth.post-urls={}
+mosip.esignet.security.auth.put-urls={}
+mosip.esignet.security.auth.get-urls={}
+
 
 mosip.esignet.security.ignore-csrf-urls=${server.servlet.path}/oidc/**,${server.servlet.path}/oauth/**,\
   ${server.servlet.path}/actuator/**,/favicon.ico,${server.servlet.path}/error,\
@@ -112,7 +118,8 @@ mosip.esignet.security.ignore-auth-urls=${server.servlet.path}/csrf/**,${server.
   ${server.servlet.path}/actuator/**,/favicon.ico,${server.servlet.path}/error,${server.servlet.path}/swagger-ui/**,\
   ${server.servlet.path}/v3/api-docs/**,${server.servlet.path}/binding/**,${server.servlet.path}/vci/**
 
-spring.security.oauth2.resourceserver.jwt.issuer-uri=${keycloak.external.url}/auth/realms/mosip
+#spring.security.oauth2.resourceserver.jwt.issuer-uri=${keycloak.external.url}/auth/realms/mosip
+spring.security.oauth2.resourceserver.jwt.issuer-uri=
 spring.security.oauth2.resourceserver.jwt.jwk-set-uri=${keycloak.external.url}/auth/realms/mosip/protocol/openid-connect/certs
 
 ##------------------------------------------ Kafka configurations ------------------------------------------------------


### PR DESCRIPTION
mosip.esignet.security.auth.post-urls={}
mosip.esignet.security.auth.put-urls={}
mosip.esignet.security.auth.get-urls={}
spring.security.oauth2.resourceserver.jwt.issuer-uri=