### PR TITLE
[DSD-6985] Update registration-processor-default.properties

### DIFF
--- a/registration-processor-default.properties
+++ b/registration-processor-default.properties
@@ -1005,5 +1005,3 @@ mosip.registration.processor.credential.default.partner-ids=digitalcardPartner,o
 mosip.registration.processor.credential.conditional.partner-id-map={'printPartner':'{"14023"} contains postalCode'}
 mosip.registration.processor.credential.conditional.no-match-partner-ids=printPartner,digitalCardInsurancePartner
 logging.level.org.apache.activemq.ActiveMQConnectionFactory=INFO
-logging.level=DEBUG
-


### PR DESCRIPTION
[DSD-6985] reverting back the logging level.

[DSD-6985]: https://mosip.atlassian.net/browse/DSD-6985?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ