### PR TITLE
registration.capture_time_out incresed from 10 sec to 20 sec

### DIFF
--- a/sandbox/registration-mz.properties
+++ b/sandbox/registration-mz.properties
@@ -70,7 +70,7 @@ mosip.registration.username_pwd_length=50
 mosip.registration.finger_print_score=70
 
 #Timeout used in MDM request.
-mosip.registration.capture_time_out=10000
+mosip.registration.capture_time_out=20000
 
 #Max Document size in Bytes allowed to be uploaded
 mosip.registration.document_size=10000000


### PR DESCRIPTION
registration.capture_time_out incresed from 10 sec to 20 sec