### PR TITLE
Capture time out has been reduced from 5 seconds to 15 seconds, and t…

### DIFF
--- a/sandbox/registration-mz.properties
+++ b/sandbox/registration-mz.properties
@@ -70,7 +70,7 @@ mosip.registration.username_pwd_length=50
 mosip.registration.finger_print_score=70
 
 #Timeout used in MDM request.
-mosip.registration.capture_time_out=5000
+mosip.registration.capture_time_out=15000
 
 #Max Document size in Bytes allowed to be uploaded
 mosip.registration.document_size=10000000
@@ -201,13 +201,13 @@ mosip.registration.refreshed_login_time = 600
 #----Threshold Quality Value for capturing the Finger Slaps. Values can be from 1 to 100---
 
 #Threshold Quality for Left Slap
-mosip.registration.leftslap_fingerprint_threshold=90
+mosip.registration.leftslap_fingerprint_threshold=60
 
 #Threshold Quality for Right Slap
-mosip.registration.rightslap_fingerprint_threshold=90
+mosip.registration.rightslap_fingerprint_threshold=60
 
 #Threshold Quality for Thumbs
-mosip.registration.thumbs_fingerprint_threshold=90
+mosip.registration.thumbs_fingerprint_threshold=60
 
 #Thereshold Quality Value for IRIS capture
 mosip.registration.iris_threshold=70


### PR DESCRIPTION
…he finger threshold has been set from 90to 70

Capture time out has been reduced from 5 seconds to 15 seconds, and the finger threshold has been set from 90to 70