### PR TITLE
[ES-2175] Added missing property ida.oidc4ida.ignore.standard.claims.list

### DIFF
--- a/id-authentication-default.properties
+++ b/id-authentication-default.properties
@@ -678,3 +678,4 @@ spring.servlet.multipart.max-file-size=10MB
 spring.servlet.multipart.max-request-size=10MB
 
 management.endpoint.env.enabled=true
+ida.oidc4ida.ignore.standard.claims.list=picture,individual_id,gender,residenceStatus


### PR DESCRIPTION
added property 
`ida.oidc4ida.ignore.standard.claims.list=picture,individual_id,gender,residenceStatus` in `id-authentication-default.properties` file.