### PR TITLE
Update registration-default.properties

### DIFF
--- a/registration-default.properties
+++ b/registration-default.properties
@@ -122,7 +122,7 @@ mosip.registration.reg_deletion_configured_days=1
 mosip.registration.pre_reg_deletion_configured_days=1
 
 #Maximum duration to which registration is permitted without sync of master dat
-mosip.registration.sync_transaction_no_of_days_limit=5
+mosip.registration.sync_transaction_no_of_days_limit=1
 
 #Allowed number of invalid login attempts
 mosip.registration.invalid_login_count=50
@@ -148,7 +148,7 @@ mosip.registration.gps_serial_port_linux=/dev/ttyusb0
 mosip.registration.gps_serial_port_windows=
 
 #Maximum no. of days for approved packet pending to be synced to server beyond which client is frozen for registration
-mosip.registration.last_export_registration_config_time=100
+mosip.registration.last_export_registration_config_time=3
 
 
 #----Default Values to be used for Auditing----


### PR DESCRIPTION
Changed mosip.registration.sync_transaction_no_of_days_limit=1 and mosip.registration.last_export_registration_config_time=3  for testing will revert back to default value after completed test.