### PR TITLE
[DSD-7336] update cache type of esignet-mock to redis

### DIFF
--- a/esignet-mock.properties
+++ b/esignet-mock.properties
@@ -227,14 +227,15 @@ mosip.esignet.cache.security.algorithm-name=AES/ECB/PKCS5Padding
 
 mosip.esignet.cache.names=clientdetails,preauth,authenticated,authcodegenerated,userinfo,linkcodegenerated,linked,linkedcode,linkedauth,consented,authtokens,bindingtransaction,vcissuance,apiRateLimit,blocked
 
-#spring.cache.type=redis
-#spring.cache.cache-names=${mosip.esignet.cache.names}
-#spring.redis.host=localhost
-#spring.redis.port=6379
+spring.cache.type=redis
+spring.cache.cache-names=${mosip.esignet.cache.names}
+spring.redis.host=redis-master-0.redis-headless.redis.svc.cluster.local
+spring.redis.port=6379
+spring.redis.password=${redis.password}
 management.health.redis.enabled=false
 
 # 'simple' cache type is only applicable only for Non-Production setup
-spring.cache.type=simple
+#spring.cache.type=simple
 mosip.esignet.cache.key.hash.algorithm=SHA3-256
 # Cache size setup is applicable only for 'simple' cache type.
 # Cache size configuration will not be considered with 'Redis' cache type


### PR DESCRIPTION
Enabling redis cache for esignet-mock to support mock-mdl usecase