### PR TITLE
Update registration-default.properties

### DIFF
--- a/registration-default.properties
+++ b/registration-default.properties
@@ -107,7 +107,7 @@ mosip.registration.lost_uin_disable_flag = Y
 mosip.registration.reg_pak_max_cnt_apprv_limit=100
 
 #Maximum no. of days for a packet pending EOD approval beyond which client is frozen for registration
-mosip.registration.reg_pak_max_time_apprv_limit=3
+mosip.registration.reg_pak_max_time_apprv_limit=1
 
 #Enable supervisor authentication feature. If y, supervisor approval will be enabled, else, will be disbaled
 mosip.registration.supervisor_approval_config_flag=Y
@@ -148,7 +148,7 @@ mosip.registration.gps_serial_port_linux=/dev/ttyusb0
 mosip.registration.gps_serial_port_windows=
 
 #Maximum no. of days for approved packet pending to be synced to server beyond which client is frozen for registration
-mosip.registration.last_export_registration_config_time=3
+mosip.registration.last_export_registration_config_time=1
 
 
 #----Default Values to be used for Auditing----


### PR DESCRIPTION
Changed registration config time for testing purpose will revert back to default value after complete testing