### PR TITLE
[MOSIP-39884] Updated kernel-default.properties for disabling the email server health check

### DIFF
--- a/kernel-default.properties
+++ b/kernel-default.properties
@@ -754,7 +754,7 @@ auth.allowed.urls=http://localhost:5000/
 mosip.kernel.masterdata.code.validate.regex=[^a-z0-9\u0600-\u06FF\u0C80-\u0CFF]
 mosip.kernel.masterdata.name.validate.regex=[^a-z\u0600-\u06FF\u0C80-\u0CFF]
 
-management.health.mail.enabled=true
+management.health.mail.enabled=false
 
 
 # html content for email notification


### PR DESCRIPTION
Updated kernel-default.properties for disabling the email server health check