### PR TITLE
[MOSIP-39884] Updated kernel-default.properties for disabling the email server health check

### DIFF
--- a/kernel-default.properties
+++ b/kernel-default.properties
@@ -69,6 +69,7 @@ spring.mail.properties.mail.smtp.auth=true
 spring.mail.debug=false
 spring.servlet.multipart.enabled=true
 spring.servlet.multipart.max-file-size=5MB
+management.health.mail.enabled=false
 
 
 ## Keymanager service


### PR DESCRIPTION
[MOSIP-39884] Updated kernel-default.properties for disabling the email server health check

[MOSIP-39884]: https://mosip.atlassian.net/browse/MOSIP-39884?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ