### PR TITLE
Update resident-default.properties

### DIFF
--- a/resident-default.properties
+++ b/resident-default.properties
@@ -1116,7 +1116,7 @@ resident.cache.expiry.time.millisec.getAllDynamicFieldByName=86400000
 
 
 #added multi languages for testing
-mosip.optional-languages=fra,ara,hin,tam,kan,spa
+mosip.optional-languages=fra,ara,hin,tam,kan
 
 # Separators
 # Usage: resident.attribute.separator.<attribute>=<separator string>


### PR DESCRIPTION
Removed 'spa' langugae from mosip.optional-languages=fra,ara,hin,tam,kan