### PR TITLE
[MOSIP-39781] config changes for adding the required audience for CRVS

### DIFF
--- a/packet-manager-default.properties
+++ b/packet-manager-default.properties
@@ -19,7 +19,7 @@ mosip.role.commons-packet.postbiometrics=BIOMETRIC_READ
 mosip.role.commons-packet.postdocument=DOCUMENT_READ
 mosip.role.commons-packet.postsearchfields=DATA_READ
 mosip.role.commons-packet.postsearchfield=DATA_READ
-auth.server.admin.allowed.audience=mosip-regproc-client,mosip-admin-client
+auth.server.admin.allowed.audience=mosip-regproc-client,mosip-admin-client,mosip-crvs1-client
 
 # Object store
 object.store.s3.accesskey=${s3.accesskey}

--- a/registration-processor-default.properties
+++ b/registration-processor-default.properties
@@ -1000,7 +1000,7 @@ mosip.role.registration.getPostsearch=REGISTRATION_ADMIN,REGISTRATION_OFFICER,RE
 mosip.role.registration.getPostlostridsearch=REGISTRATION_ADMIN,REGISTRATION_OFFICER,ZONAL_ADMIN,GLOBAL_ADMIN
 mosip.role.registration.getPostsync=REGISTRATION_ADMIN,REGISTRATION_PROCESSOR,REGISTRATION_OFFICER,REGISTRATION_SUPERVISOR,RESIDENT
 mosip.role.registration.getPostsyncv2=REGISTRATION_ADMIN,REGISTRATION_PROCESSOR,REGISTRATION_OFFICER,REGISTRATION_SUPERVISOR,RESIDENT
-auth.server.admin.allowed.audience=mosip-regproc-client,mosip-admin-client,mosip-resident-client,mosip-reg-client
+auth.server.admin.allowed.audience=mosip-regproc-client,mosip-admin-client,mosip-resident-client,mosip-reg-client,mosip-crvs1-client
 mosip.regproc.cbeff-validation.mandatory.modalities=Right,Left,Left RingFinger,Left LittleFinger,Right RingFinger,Left Thumb,Left IndexFinger,Right IndexFinger,Right LittleFinger,Right MiddleFinger,Left MiddleFinger,Right Thumb,EXCEPTION_PHOTO
 
 mosip.regproc.landing.zone.account.name=landing-zone


### PR DESCRIPTION
[MOSIP-39781] config changes for adding the required audience for CRVS

[MOSIP-39781]: https://mosip.atlassian.net/browse/MOSIP-39781?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ