### PR TITLE
Update registration-processor-default.properties

### DIFF
--- a/registration-processor-default.properties
+++ b/registration-processor-default.properties
@@ -1009,3 +1009,5 @@ uingenerator.lost.packet.allowed.update.fields=phone,email,permanentAddress
 
 ##timeout in milliseconds for health check registrer
 mosip.regproc.health-check.handler-timeout=2000
+
+logging.level.io.mosip.registration.processor.message.sender.service.impl=DEBUG


### PR DESCRIPTION
Enableing debuging for io.mosip.registration.processor.message.sender.service.impl class