### PR TITLE
Update admin-default.properties

### DIFF
--- a/admin-default.properties
+++ b/admin-default.properties
@@ -71,7 +71,7 @@ mosip.admin.security.policy.userrole-auth-url=${mosip.kernel.authmanager.url}/v1
 
 ## Masterdata cards
 
-mosip.admin.masterdata.lang-code=eng,ara,fra
+mosip.admin.masterdata.lang-code=eng,ara,fra,hin,tam,kan
 mosip.admin-services.required.roles=GLOBAL_ADMIN
 
 #masterdata machine

--- a/application-default.properties
+++ b/application-default.properties
@@ -280,6 +280,9 @@ mosip.kernel.virus-scanner.port=3310
 mosip.kernel.transliteration.arabic-language-code=ara
 mosip.kernel.transliteration.english-language-code=eng
 mosip.kernel.transliteration.french-language-code=fra
+mosip.kernel.transliteration.hindi-language-code=hin
+mosip.kernel.transliteration.tamil-language-code=tam
+mosip.kernel.transliteration.kannada-language-code=kan
 # Added this property for backward compatibility as it is misspelled in <1.2.0 versions of kernel-transliteration library
 mosip.kernel.transliteration.franch-language-code=fra
 
@@ -417,12 +420,12 @@ websub.publish.url=${mosip.websub.url}/hub/
 
 mosip.mandatory-languages=eng
 ## Leave blank if no optional langauges
-mosip.optional-languages=ara,fra
-mosip.min-languages.count=2
-mosip.max-languages.count=3
+mosip.optional-languages=ara,fra,hin,tam,kan
+mosip.min-languages.count=5
+mosip.max-languages.count=6
 
 # These are default languages used for sending notifications
-mosip.default.template-languages=eng,ara,fra
+mosip.default.template-languages=eng,ara,fra,hin,tam,kan
 
 # Config key to pick the preferred language for communicating to the Resident
 mosip.default.user-preferred-language-attribute=preferredLang

--- a/application-default.properties
+++ b/application-default.properties
@@ -94,9 +94,9 @@ mosip.idrepo.identity.bioAttributes=individualBiometrics,parentOrGuardianBiometr
 mosip.country.code=MOR
 
 ## Language supported by platform
-mosip.supported-languages=eng,ara,fra
+mosip.supported-languages=eng,ara,fra,hin,tam,kan
 mosip.right_to_left_orientation=ara
-mosip.left_to_right_orientation=eng,fra
+mosip.left_to_right_orientation=eng,fra,hin,tam,kan
 
 ## Application IDs
 mosip.prereg.app-id=PRE_REGISTRATION

--- a/mimoto-default.properties
+++ b/mimoto-default.properties
@@ -102,10 +102,10 @@ mosip.country.code=MOR
 registration.processor.signature.isEnabled=true
 
 # Language Supported By Platform - ISO
-mosip.supported-languages=eng,ara,fra
+mosip.supported-languages=eng,ara,fra,hin,tam,kan
 
 mosip.template-language=eng
-mosip.optional-languages=ara,fra
+mosip.optional-languages=ara,fra,hin,tam,kan
 mosip.mandatory-languages=eng
 
 # mosip.primary-language=eng

--- a/print-default.properties
+++ b/print-default.properties
@@ -55,9 +55,9 @@ registration.processor.signature.isEnabled=true
 
 ## Country specific
 mosip.country.code=MOR
-mosip.supported-languages=eng,ara,fra
+mosip.supported-languages=eng,ara,fra,hin,tam,kan
 mosip.template-language=eng
-mosip.optional-languages=ara,fra
+mosip.optional-languages=kan,ara,fra,tam,hin
 mosip.mandatory-languages=eng
 
 ## CBEFF util

--- a/resident-app-default.properties
+++ b/resident-app-default.properties
@@ -96,10 +96,10 @@ mosip.country.code=MOR
 registration.processor.signature.isEnabled=true
 
 # Language Supported By Platform - ISO
-mosip.supported-languages=eng,ara,fra
+mosip.supported-languages=eng,ara,fra,hin,tam,kan
 
 mosip.template-language=eng
-mosip.optional-languages=ara,fra
+mosip.optional-languages=ara,fra,hin,tam,kan
 mosip.mandatory-languages=eng
 
 # mosip.primary-language=eng


### PR DESCRIPTION
added the mosip.admin.masterdata.lang-code=eng,ara,fra,hin,tam,kan