### PR TITLE
[MOSIP-41135] Change the packetmanager.packet.signature.disable-verification configuration to false for security reason by default.

### DIFF
--- a/application-default.properties
+++ b/application-default.properties
@@ -357,7 +357,8 @@ mosip.registration.gps_device_enable_flag=n
 packetmanager.default.read.strategy=defaultPriority
 packetmanager.default.priority=source:REGISTRATION_CLIENT\/process:BIOMETRIC_CORRECTION|NEW|UPDATE|LOST,source:RESIDENT\/process:ACTIVATED|DEACTIVATED|RES_UPDATE|RES_REPRINT,source:OPENCRVS\/process:OPENCRVS_NEW,source:CRVS1\/process:CRVS_NEW|CRVS_DEATH
 packetmanager.name.source={default:'REGISTRATION_CLIENT',resident:'RESIDENT',opencrvs:'OPENCRVS'}
-packetmanager.packet.signature.disable-verification=true
+# This configuration is used for disabling packet signature validation.
+packetmanager.packet.signature.disable-verification=false
 mosip.commons.packetnames=id,evidence,optional
 provider.packetreader.mosip=source:REGISTRATION_CLIENT,process:NEW|UPDATE|LOST|BIOMETRIC_CORRECTION,classname:io.mosip.commons.packet.impl.PacketReaderImpl
 provider.packetreader.resident=source:RESIDENT,process:ACTIVATED|DEACTIVATED|RES_UPDATE|LOST|RES_REPRINT,classname:io.mosip.commons.packet.impl.PacketReaderImpl


### PR DESCRIPTION
[MOSIP-41135] Change the packetmanager.packet.signature.disable-verification configuration to false for security reason by default.

[MOSIP-41135]: https://mosip.atlassian.net/browse/MOSIP-41135?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ