### PR TITLE
[MOSIP-42364] - cherry-pick for dev1 branch from [MOSIP-41867] Disable loading of tags from packet manager for Packet Uploader Stage for performance improvement (#8990) (#9072)

### DIFF
--- a/registration-processor-default.properties
+++ b/registration-processor-default.properties
@@ -532,8 +532,9 @@ mosip.regproc.packet.uploader.server.port=8087
 mosip.regproc.packet.uploader.server.servlet.path=/registrationprocessor/v1/uploader
 mosip.regproc.packet.uploader.eventbus.port=5714
 packet.manager.iteration.addition.enabled=true
-
 packet.uploader.stage=registration-processor-packet-uploader-stage
+# Flag to disable the copying of tags from the packet manger to the message event
+mosip.regproc.packet.uploader.message.tag.loading.disable=true
 
 #packet-validator-stage
 mosip.regproc.packet.validator.eventbus.kafka.commit.type=batch


### PR DESCRIPTION
…Uploader Stage for performance improvement (#8990) (#9072)

[MOSIP-41867] Disable loading of tags from packet manager for Packet Uploader Stage for performance improvement

[MOSIP-41867]: https://mosip.atlassian.net/browse/MOSIP-41867?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ