### PR TITLE
[MOSIP-42364]: cherry-pick(dev1) from [MOSIP-42545] Disable Caffeine Cache in ABIS Handler and Middleware Stages #9163

### DIFF
--- a/registration-processor-default.properties
+++ b/registration-processor-default.properties
@@ -674,6 +674,8 @@ mosip.regproc.abis.handler.eventbus.port=5726
 mosip.regproc.abis.handler.server.servlet.path=/registrationprocessor/v1/abishandler
 mosip.regproc.abis.handler.biometric-modalities-segments-mapping-for-age-group={'MINOR' : {'Finger' : {'Left Thumb','Left LittleFinger','Left IndexFinger','Left MiddleFinger','Left RingFinger','Right Thumb','Right LittleFinger','Right IndexFinger','Right MiddleFinger','Right RingFinger'},'Iris' : {'Left', 'Right'}}, 'INFANT' : {'Face': {'Face'}}, 'ADULT': {'Finger': {'Left Thumb','Left LittleFinger','Left IndexFinger','Left MiddleFinger','Left RingFinger','Right Thumb','Right LittleFinger','Right IndexFinger','Right MiddleFinger','Right RingFinger'},'Iris' : {'Left', 'Right'}}, 'DEFAULT' : {'Finger' : {'Left Thumb','Left LittleFinger','Left IndexFinger','Left MiddleFinger','Left RingFinger','Right Thumb','Right LittleFinger','Right IndexFinger','Right MiddleFinger','Right RingFinger'},'Iris' : {'Left', 'Right'}}}
 mosip.regproc.abis.handler.biometric-segments-exceptions-mapping={'Left Thumb' : 'leftThumb','Right Thumb' : 'rightThumb','Left MiddleFinger' : 'leftMiddle','Left RingFinger' : 'leftRing','Left LittleFinger' : 'leftLittle','Left IndexFinger' : 'leftIndex','Right MiddleFinger' : 'rightMiddle','Right RingFinger' : 'rightRing','Right LittleFinger' : 'rightLittle','Right IndexFinger' : 'rightIndex','Left' : 'leftEye','Right' : 'rightEye'}
+# Caffeine cache is disabled because both demo-dedupe and bio-dedupe stages pass through this stage, and they produce the same Kafka key. As a result, the packet is treated as a duplicate within the cache expiry window and gets dropped.
+mosip.regproc.abis.handler.caffeine.cache.enable=false
 
 #bio-dedupe-stage
 mosip.regproc.bio.dedupe.eventbus.kafka.commit.type=batch
@@ -708,6 +710,8 @@ mosip.regproc.abis.middleware.message.expiry-time-limit=${mosip.regproc.common.s
 mosip.regproc.abis.middleware.server.port=8091
 mosip.regproc.abis.middleware.eventbus.port=5888
 mosip.regproc.abis.middleware.server.servlet.path=/registrationprocessor/v1/abismiddleware
+# Caffeine cache is disabled because both demo-dedupe and bio-dedupe stages pass through this stage, and they produce the same Kafka key. As a result, the packet is treated as a duplicate within the cache expiry window and gets dropped.
+mosip.regproc.abis.middleware.caffeine.cache.enable=false
 
 # Biometric extraction stage
 mosip.regproc.biometric.extraction.eventbus.kafka.commit.type=batch


### PR DESCRIPTION
…tages (#9163)

* Disable Caffeine Cache in ABIS Handler and Middleware Stages



* remove space



---------