### PR TITLE
"[MOSIP-43116]updated placeholder instead of hardcoded postgres host and port v alues"

### DIFF
--- a/admin-default.properties
+++ b/admin-default.properties
@@ -13,8 +13,8 @@ mosip.admin.request-id=ADMIN.REQUEST
 ## Database properties
 # Database hostname below is assuming postgres is running inside cluster in 'postgres' namespace
 # If database is external to production, provide the DNS or ip of the host and port 
-mosip.kernel.database.hostname=postgres-postgresql.postgres
-mosip.kernel.database.port=5432
+mosip.kernel.database.hostname=${mosip.database.hostname.override:postgres-postgresql.postgres}
+mosip.kernel.database.port=${mosip.database.port.override:5432}
 
 ## Account management
 authmanager.base.url=${mosip.kernel.authmanager.url}/v1/authmanager

--- a/application-default.properties
+++ b/application-default.properties
@@ -182,7 +182,12 @@ mosip.kernel.vid.restricted-numbers=786,666
 
 ## UIN
 mosip.kernel.uin.length=10
-mosip.kernel.uin.min-unused-threshold=200000
+
+## Change for Production
+# As per production hardening, update the value of  
+# mosip.kernel.uin.min-unused-threshold  
+# from 10000 to 200000 during production deployment
+mosip.kernel.uin.min-unused-threshold=10000
 mosip.kernel.uin.uins-to-generate=500000
 mosip.kernel.uin.restricted-numbers=786,666
 # Upper bound of number of digits in sequence allowed in id. For example if

--- a/compliance-toolkit-default.properties
+++ b/compliance-toolkit-default.properties
@@ -15,8 +15,8 @@
 
 ##DB properties
 javax.persistence.jdbc.driver=org.postgresql.Driver
-mosip.database.ip=postgres-postgresql.postgres
-mosip.database.port=5432
+mosip.database.ip=${mosip.database.hostname.override:postgres-postgresql.postgres}
+mosip.database.port=${mosip.database.port.override:5432}
 javax.persistence.jdbc.url=jdbc:postgresql://${mosip.database.ip}:${mosip.database.port}/mosip_toolkit?useSSL=false
 javax.persistence.jdbc.user=toolkituser
 javax.persistence.jdbc.password=${db.dbuser.password}

--- a/digital-card-default.properties
+++ b/digital-card-default.properties
@@ -1,8 +1,8 @@
 ## Database properties
 # Database hostname below is assuming postgres is running inside cluster in 'postgres' namespace
 # If database is external to production, provide the DNS or ip of the host and port
-mosip.digitalcard.database.hostname=postgres-postgresql.postgres
-mosip.digitalcard.database.port=5432
+mosip.digitalcard.database.hostname=${mosip.database.hostname.override:postgres-postgresql.postgres}
+mosip.digitalcard.database.port=${mosip.database.port.override:5432}
 
 # Websub
 ## webusb properties that used to subscribe and publish event based on specified topic

--- a/esignet-default.properties
+++ b/esignet-default.properties
@@ -321,8 +321,8 @@ mosip.esignet.discovery.key-values={'issuer': '${mosip.esignet.domain.url}' ,\
 
 ##----------------------------------------- Database properties --------------------------------------------------------
 
-mosip.esignet.database.hostname=postgres-postgresql.postgres
-mosip.esignet.database.port=5432
+mosip.esignet.database.hostname=${mosip.database.hostname.override:postgres-postgresql.postgres}
+mosip.esignet.database.port=${mosip.database.port.override:5432}
 spring.datasource.url=jdbc:postgresql://${mosip.esignet.database.hostname}:${mosip.esignet.database.port}/mosip_esignet?currentSchema=esignet
 spring.datasource.username=esignetuser
 spring.datasource.password=${db.dbuser.password}

--- a/hotlist-default.properties
+++ b/hotlist-default.properties
@@ -6,8 +6,8 @@
 spring.application.name=HOTLIST
 
 ## DB
-mosip.hotlist.db.url=postgres-postgresql.postgres
-mosip.hotlist.db.port=5432
+mosip.hotlist.db.url=${mosip.database.hostname.override:postgres-postgresql.postgres}
+mosip.hotlist.db.port=${mosip.database.port.override:5432}
 mosip.hotlist.db.db-name=mosip_hotlist
 mosip.hotlist.db.username=hotlistuser
 mosip.hotlist.db.password=${db.dbuser.password}

--- a/id-authentication-default.properties
+++ b/id-authentication-default.properties
@@ -33,8 +33,8 @@ mosip.ida.auth.appId=ida
 ## Database
 # Database hostname below is assuming postgres is running inside cluster in 'postgres' namespace
 # If database is external to production, provide the DNS or ip of the host and port 
-mosip.ida.database.hostname=postgres-postgresql.postgres
-mosip.ida.database.port=5432
+mosip.ida.database.hostname=${mosip.database.hostname.override:postgres-postgresql.postgres}
+mosip.ida.database.port=${mosip.database.port.override:5432}
 mosip.ida.database.user=idauser
 mosip.ida.database.password=${db.dbuser.password}
 

--- a/id-repository-default.properties
+++ b/id-repository-default.properties
@@ -404,7 +404,7 @@ mosip.kernel.tokenid.partnercode.salt=${mosip.kernel.partnercode.salt}
 # Enabling below property will start logging performance logs in identity and vid service
 mosip.idrepo.aspect-logging.enabled=false
 
-auth.server.admin.allowed.audience=mosip-regproc-client,mosip-prereg-client,mosip-admin-client,mosip-crereq-client,mosip-creser-client,mosip-datsha-client,mosip-ida-client,mosip-resident-client,mosip-reg-client,mpartner-default-print,mosip-idrepo-client,mpartner-default-auth,mosip-syncdata-client,mosip-masterdata-client,mosip-idrepo-client,mosip-pms-client,mosip-hotlist-client,opencrvs-partner,mpartner-default-digitalcard,mpartner-default-mobile,mosip-signup-client,mosip-testrig-client
+auth.server.admin.allowed.audience=mosip-regproc-client,mosip-prereg-client,mosip-admin-client,mosip-crereq-client,mosip-creser-client,mosip-datsha-client,mosip-ida-client,mosip-resident-client,mosip-reg-client,mpartner-default-print,mosip-idrepo-client,mpartner-default-auth,mosip-syncdata-client,mosip-masterdata-client,mosip-idrepo-client,mosip-pms-client,mosip-hotlist-client,opencrvs-partner,mpartner-default-digitalcard,mpartner-default-mobile,mosip-signup-client
 #openapi properties to sort tag and operations of id-repository services
 springdoc.swagger-ui.tagsSorter=alpha
 springdoc.swagger-ui.operationsSorter=alpha

--- a/id-repository-default.properties
+++ b/id-repository-default.properties
@@ -17,8 +17,8 @@ management.endpoint.restart.enabled=true
 
 # Database hostname below is assuming postgres is running inside cluster in 'postgres' namespace
 # If database is external to production, provide the DNS or ip of the host and port 
-mosip.idrepo.db.url=postgres-postgresql.postgres
-mosip.idrepo.db.port=5432
+mosip.idrepo.db.url=${mosip.database.hostname.override:postgres-postgresql.postgres}
+mosip.idrepo.db.port=${mosip.database.port.override:5432}
 mosip.idrepo.db.identity.db-name=mosip_idrepo
 mosip.idrepo.db.identity.username=idrepouser
 mosip.idrepo.db.identity.password=${db.dbuser.password}
@@ -244,8 +244,8 @@ mosip.idrepo.update-vid.rest.headers.mediaType=application/json
 mosip.idrepo.update-vid.rest.timeout=100
 
 ## Credential request generator
-mosip.credential.service.database.hostname=postgres-postgresql.postgres
-mosip.credential.service.database.port=5432
+mosip.credential.service.database.hostname=${mosip.database.hostname.override:postgres-postgresql.postgres}
+mosip.credential.service.database.port=${mosip.database.port.override:5432}
 
 mosip.credential.service.jdbc.url=jdbc:postgresql://${mosip.credential.service.database.hostname}:${mosip.credential.service.database.port}/mosip_credential?currentSchema=credential
 mosip.credential.service.jdbc.user=credentialuser
@@ -404,7 +404,7 @@ mosip.kernel.tokenid.partnercode.salt=${mosip.kernel.partnercode.salt}
 # Enabling below property will start logging performance logs in identity and vid service
 mosip.idrepo.aspect-logging.enabled=false
 
-auth.server.admin.allowed.audience=mosip-regproc-client,mosip-prereg-client,mosip-admin-client,mosip-crereq-client,mosip-creser-client,mosip-datsha-client,mosip-ida-client,mosip-resident-client,mosip-reg-client,mpartner-default-print,mosip-idrepo-client,mpartner-default-auth,mosip-syncdata-client,mosip-masterdata-client,mosip-idrepo-client,mosip-pms-client,mosip-hotlist-client,opencrvs-partner,mpartner-default-digitalcard,mpartner-default-mobile,mosip-signup-client
+auth.server.admin.allowed.audience=mosip-regproc-client,mosip-prereg-client,mosip-admin-client,mosip-crereq-client,mosip-creser-client,mosip-datsha-client,mosip-ida-client,mosip-resident-client,mosip-reg-client,mpartner-default-print,mosip-idrepo-client,mpartner-default-auth,mosip-syncdata-client,mosip-masterdata-client,mosip-idrepo-client,mosip-pms-client,mosip-hotlist-client,opencrvs-partner,mpartner-default-digitalcard,mpartner-default-mobile,mosip-signup-client,mosip-testrig-client
 #openapi properties to sort tag and operations of id-repository services
 springdoc.swagger-ui.tagsSorter=alpha
 springdoc.swagger-ui.operationsSorter=alpha

--- a/idp-binding-default.properties
+++ b/idp-binding-default.properties
@@ -53,8 +53,8 @@ management.health.redis.enabled=false
 
 ##----------------------------------------- Database properties --------------------------------------------------------
 
-mosip.idp.database.hostname=postgres-postgresql.postgres
-mosip.idp.database.port=5432
+mosip.idp.database.hostname=${mosip.database.hostname.override:postgres-postgresql.postgres}
+mosip.idp.database.port=${mosip.database.port.override:5432}
 spring.datasource.url=jdbc:postgresql://${mosip.idp.database.hostname}:${mosip.idp.database.port}/mosip_idpbinding?currentSchema=idpbinding
 spring.datasource.username=idpbindinguser
 spring.datasource.password=${db.dbuser.password}

--- a/idp-default.properties
+++ b/idp-default.properties
@@ -182,8 +182,8 @@ mosip.idp.discovery.key-values={'issuer': '${mosip.idp.discovery.issuer-id}' ,\
 
 ##----------------------------------------- Database properties -------------------------------------------
 
-mosip.idp.database.hostname=postgres-postgresql.postgres
-mosip.idp.database.port=5432
+mosip.idp.database.hostname=${mosip.database.hostname.override:postgres-postgresql.postgres}
+mosip.idp.database.port=${mosip.database.port.override:5432}
 spring.datasource.url=jdbc:postgresql://${mosip.idp.database.hostname}:${mosip.idp.database.port}/mosip_idp?currentSchema=idp
 spring.datasource.username=idpuser
 spring.datasource.password=${db.dbuser.password}

--- a/kernel-default.properties
+++ b/kernel-default.properties
@@ -117,7 +117,7 @@ mosip.kernel.ida.secret.key=${mosip.ida.client.secret}
 ## VID generator service
 # Change for Production
 # As per production hardening, update the value of  
-# mosip.kernel.uin.min-unused-threshold  
+# mosip.kernel.vid.min-unused-threshold  
 # from 10000 to 100000 during production deployment
 
 mosip.kernel.vid.min-unused-threshold=10000
@@ -438,7 +438,7 @@ scheduling.job.cron=0 0 2 * * ?
 #To fetch user details based on user id and user name in zone API's 
 zone.user.details.url=${mosip.kernel.authmanager.url}/v1/authmanager/userdetails
 
-auth.server.admin.allowed.audience=mosip-toolkit-android-client,mosip-toolkit-client,mosip-regproc-client,mosip-prereg-client,mosip-admin-client,mosip-crereq-client,mosip-creser-client,mosip-datsha-client,mosip-ida-client,mosip-resident-client,mosip-reg-client,mpartner-default-print,mosip-idrepo-client,mpartner-default-auth,mosip-syncdata-client,mosip-masterdata-client,mosip-idrepo-client,mosip-pms-client,mosip-hotlist-client,mobileid_newlogic,opencrvs-partner,mosip-deployment-client,mpartner-default-digitalcard,mpartner-default-mobile,mosip-signup-client,mosip-testrig-client
+auth.server.admin.allowed.audience=mosip-toolkit-android-client,mosip-toolkit-client,mosip-regproc-client,mosip-prereg-client,mosip-admin-client,mosip-crereq-client,mosip-creser-client,mosip-datsha-client,mosip-ida-client,mosip-resident-client,mosip-reg-client,mpartner-default-print,mosip-idrepo-client,mpartner-default-auth,mosip-syncdata-client,mosip-masterdata-client,mosip-idrepo-client,mosip-pms-client,mosip-hotlist-client,mobileid_newlogic,opencrvs-partner,mosip-deployment-client,mpartner-default-digitalcard,mpartner-default-mobile,mosip-signup-client
 mosip.iam.adapter.appid=admin
 mosip.iam.adapter.clientid=mosip-admin-client
 mosip.iam.adapter.clientsecret=${mosip.admin.client.secret}

--- a/kernel-default.properties
+++ b/kernel-default.properties
@@ -115,7 +115,12 @@ mosip.kernel.ida.client.id=mosip-ida-client
 mosip.kernel.ida.secret.key=${mosip.ida.client.secret}
 
 ## VID generator service
-mosip.kernel.vid.min-unused-threshold=100000
+# Change for Production
+# As per production hardening, update the value of  
+# mosip.kernel.uin.min-unused-threshold  
+# from 10000 to 100000 during production deployment
+
+mosip.kernel.vid.min-unused-threshold=10000
 mosip.kernel.vid.vids-to-generate=200000
 mosip.kernel.vid.time-to-release-after-expiry=5
 mosip.kernel.vid.pool-population-timeout=10000000
@@ -150,8 +155,8 @@ kernel.prid.revoke-scheduler-days_of_week=*
 ## Database properties
 # Database hostname below is assuming postgres is running inside cluster in 'postgres' namespace
 # If database is external to production, provide the DNS or ip of the host and port 
-mosip.kernel.database.hostname=postgres-postgresql.postgres
-mosip.kernel.database.port=5432
+mosip.kernel.database.hostname=${mosip.database.hostname.override:postgres-postgresql.postgres}
+mosip.kernel.database.port=${mosip.database.port.override:5432}
 
 javax.persistence.jdbc.driver=org.postgresql.Driver
 hibernate.dialect=org.hibernate.dialect.PostgreSQL95Dialect
@@ -433,7 +438,7 @@ scheduling.job.cron=0 0 2 * * ?
 #To fetch user details based on user id and user name in zone API's 
 zone.user.details.url=${mosip.kernel.authmanager.url}/v1/authmanager/userdetails
 
-auth.server.admin.allowed.audience=mosip-toolkit-android-client,mosip-toolkit-client,mosip-regproc-client,mosip-prereg-client,mosip-admin-client,mosip-crereq-client,mosip-creser-client,mosip-datsha-client,mosip-ida-client,mosip-resident-client,mosip-reg-client,mpartner-default-print,mosip-idrepo-client,mpartner-default-auth,mosip-syncdata-client,mosip-masterdata-client,mosip-idrepo-client,mosip-pms-client,mosip-hotlist-client,mobileid_newlogic,opencrvs-partner,mosip-deployment-client,mpartner-default-digitalcard,mpartner-default-mobile,mosip-signup-client
+auth.server.admin.allowed.audience=mosip-toolkit-android-client,mosip-toolkit-client,mosip-regproc-client,mosip-prereg-client,mosip-admin-client,mosip-crereq-client,mosip-creser-client,mosip-datsha-client,mosip-ida-client,mosip-resident-client,mosip-reg-client,mpartner-default-print,mosip-idrepo-client,mpartner-default-auth,mosip-syncdata-client,mosip-masterdata-client,mosip-idrepo-client,mosip-pms-client,mosip-hotlist-client,mobileid_newlogic,opencrvs-partner,mosip-deployment-client,mpartner-default-digitalcard,mpartner-default-mobile,mosip-signup-client,mosip-testrig-client
 mosip.iam.adapter.appid=admin
 mosip.iam.adapter.clientid=mosip-admin-client
 mosip.iam.adapter.clientsecret=${mosip.admin.client.secret}

--- a/mock-identity-system-default.properties
+++ b/mock-identity-system-default.properties
@@ -27,8 +27,8 @@
 
 ##----------------------------------------- Database properties --------------------------------------------------------
 
-mosip.mockidentitysystem.database.hostname=postgres-postgresql.postgres
-mosip.mockidentitysystem.database.port=5432
+mosip.mockidentitysystem.database.hostname=${mosip.database.hostname.override:postgres-postgresql.postgres}
+mosip.mockidentitysystem.database.port=${mosip.database.port.override:5432}
 spring.datasource.url=jdbc:postgresql://${mosip.mockidentitysystem.database.hostname}:${mosip.mockidentitysystem.database.port}/mosip_mockidentitysystem?currentSchema=mockidentitysystem
 spring.datasource.username=mockidsystemuser
 spring.datasource.password=${db.dbuser.password}

--- a/opencrvs-default.properties
+++ b/opencrvs-default.properties
@@ -82,7 +82,7 @@ objectstore.crypto.name=OnlinePacketCryptoServiceImpl
 objectstore.adapter.name=PosixAdapter
 object.store.base.location=./packets/mosip-opencrvs/
 
-mosip.opencrvs.db.datasource.jdbc-url=jdbc:postgresql://${mosip.database.hostname.override:postgres-postgresql.postgres}:5432/mosip_opencrvs
+mosip.opencrvs.db.datasource.jdbc-url=jdbc:postgresql://${mosip.database.hostname.override:postgres-postgresql.postgres}:${mosip.database.port.override:5432}/mosip_opencrvs
 mosip.opencrvs.db.datasource.username=opencrvsuser
 # mosip.opencrvs.db.datasource.password=
 mosip.opencrvs.db.datasource.birth.transaction.table=opencrvs.birth_transactions

--- a/opencrvs-default.properties
+++ b/opencrvs-default.properties
@@ -82,7 +82,7 @@ objectstore.crypto.name=OnlinePacketCryptoServiceImpl
 objectstore.adapter.name=PosixAdapter
 object.store.base.location=./packets/mosip-opencrvs/
 
-mosip.opencrvs.db.datasource.jdbc-url=jdbc:postgresql://postgres-postgresql.postgres:5432/mosip_opencrvs
+mosip.opencrvs.db.datasource.jdbc-url=jdbc:postgresql://${mosip.database.hostname.override:postgres-postgresql.postgres}:5432/mosip_opencrvs
 mosip.opencrvs.db.datasource.username=opencrvsuser
 # mosip.opencrvs.db.datasource.password=
 mosip.opencrvs.db.datasource.birth.transaction.table=opencrvs.birth_transactions

--- a/partner-management-default.properties
+++ b/partner-management-default.properties
@@ -329,5 +329,7 @@ mosip.pms.esignet.oauth-client-update-url=${mosip.esignet.service.url}/v1/esigne
 ## IDP Service api to fetch OIDC Client configuration 
 mosip.pms.esignet.config-url=${mosip.esignet.service.url}/v1/esignet/oidc/.well-known/openid-configuration
 
+# Indicates whether the OIDC client is available in MOSIP platform
+mosip.pms.oidc.client.available=false
 # Indicates whether the root and intermediate CA certificates are available in MOSIP platform
 mosip.pms.root.and.intermediate.certificates.available=false

--- a/partner-management-default.properties
+++ b/partner-management-default.properties
@@ -10,8 +10,8 @@
 ## Database
 ## Database hostname below is assuming postgres is running inside cluster in 'postgres' namespace
 ## If database is external to production, provide the DNS or ip of the host and port
-mosip.pmp.database.hostname=postgres-postgresql.postgres
-mosip.pmp.database.port=5432
+mosip.pmp.database.hostname=${mosip.database.hostname.override:postgres-postgresql.postgres}
+mosip.pmp.database.port=${mosip.database.port.override:5432}
 mosip.pmp.database.user=pmsuser
 mosip.pmp.database.password=${db.dbuser.password}
 
@@ -331,3 +331,4 @@ mosip.pms.esignet.config-url=${mosip.esignet.service.url}/v1/esignet/oidc/.well-
 
 # Indicates whether the root and intermediate CA certificates are available in MOSIP platform
 mosip.pms.root.and.intermediate.certificates.available=false
+mosip.pms.oidc.client.available=false

--- a/partner-management-default.properties
+++ b/partner-management-default.properties
@@ -331,4 +331,3 @@ mosip.pms.esignet.config-url=${mosip.esignet.service.url}/v1/esignet/oidc/.well-
 
 # Indicates whether the root and intermediate CA certificates are available in MOSIP platform
 mosip.pms.root.and.intermediate.certificates.available=false
-mosip.pms.oidc.client.available=false

--- a/pms-migration-utility-default.properties
+++ b/pms-migration-utility-default.properties
@@ -38,8 +38,8 @@ pmp.partner.certificate.get.rest.uri=${mosip.kernel.keymanager.url}/v1/keymanage
 ## Database
 ## Database hostname below is assuming postgres is running inside cluster in 'postgres' namespace
 ## If database is external to production, provide the DNS or ip of the host and port 
-mosip.pmp.database.hostname=postgres-postgresql.postgres
-mosip.pmp.database.port=5432
+mosip.pmp.database.hostname=${mosip.database.hostname.override:postgres-postgresql.postgres}
+mosip.pmp.database.port=${mosip.database.port.override:5432}
 mosip.pmp.database.user=pmsuser
 mosip.pmp.database.password=${db.dbuser.password}
 

--- a/pre-registration-default.properties
+++ b/pre-registration-default.properties
@@ -15,8 +15,8 @@
 # Database hostname below is assuming postgres is running inside cluster in 'postgres' namespace
 # If database is external to production, provide the DNS or ip of the host and port 
 javax.persistence.jdbc.driver=org.postgresql.Driver
-mosip.database.ip=postgres-postgresql.postgres
-mosip.database.port=5432
+mosip.database.ip=${mosip.database.hostname.override:postgres-postgresql.postgres}
+mosip.database.port=${mosip.database.port.override:5432}
 javax.persistence.jdbc.url=jdbc:postgresql://${mosip.database.ip}:${mosip.database.port}/mosip_prereg?useSSL=false
 javax.persistence.jdbc.user=prereguser
 javax.persistence.jdbc.password=${db.dbuser.password}

--- a/registration-processor-default.properties
+++ b/registration-processor-default.properties
@@ -33,8 +33,8 @@ registration.processor.bio.dedupe.reprocess.buffer.time=900
 ## Database properties
 # Database hostname below is assuming postgres is running inside cluster in 'postgres' namespace
 # If database is external to production, provide the DNS or ip of the host and port 
-mosip.registration.processor.database.hostname=postgres-postgresql.postgres
-mosip.registration.processor.database.port=5432
+mosip.registration.processor.database.hostname=${mosip.database.hostname.override:postgres-postgresql.postgres}
+mosip.registration.processor.database.port=${mosip.database.port.override:5432}
 javax.persistence.jdbc.driver=org.postgresql.Driver
 javax.persistence.jdbc.url=jdbc:postgresql://${mosip.registration.processor.database.hostname}:${mosip.registration.processor.database.port}/mosip_regprc?currentSchema=regprc
 javax.persistence.jdbc.user=regprcuser

--- a/resident-default.properties
+++ b/resident-default.properties
@@ -137,8 +137,8 @@ mosip.resident.get.pending.drafts.version=1.0
 mosip.resident.discard.pending.drafts.version=1.0
 
 #Database config
-mosip.resident.database.hostname=postgres-postgresql.postgres
-mosip.resident.database.port=5432
+mosip.resident.database.hostname=${mosip.database.hostname.override:postgres-postgresql.postgres}
+mosip.resident.database.port=${mosip.database.port.override:5432}
 
 javax.persistence.jdbc.driver=org.postgresql.Driver
 javax.persistence.jdbc.url=jdbc:postgresql://${mosip.resident.database.hostname}:${mosip.resident.database.port}/mosip_resident

--- a/syncdata-default.properties
+++ b/syncdata-default.properties
@@ -132,8 +132,8 @@ kernel.prid.revoke-scheduler-days_of_week=*
 ## Database properties
 # Database hostname below is assuming postgres is running inside cluster in 'postgres' namespace
 # If database is external to production, provide the DNS or ip of the host and port 
-mosip.kernel.database.hostname=postgres-postgresql.postgres
-mosip.kernel.database.port=5432
+mosip.kernel.database.hostname=${mosip.database.hostname.override:postgres-postgresql.postgres}
+mosip.kernel.database.port=${mosip.database.port.override:5432}
 
 javax.persistence.jdbc.driver=org.postgresql.Driver
 hibernate.dialect=org.hibernate.dialect.PostgreSQL95Dialect


### PR DESCRIPTION
And 
When using higher threshold values for production hardening:
mosip.kernel.uin.min-unused-threshold=200000
mosip.kernel.vid.min-unused-threshold=100000
The ID generator pod was experiencing extremely long startup times (~1 hour), which was impacting,

reducing threshold values to optimize startup performance for faaster startup of idgeneartor pod:
mosip.kernel.uin.min-unused-threshold=10000 (reduced from 200000)
mosip.kernel.vid.min-unused-threshold=10000 (reduced from 100000)