### PR TITLE
[MOSIP-43104] Change expiry periods for license and policy to 100 years

### DIFF
--- a/partner-management-default.properties
+++ b/partner-management-default.properties
@@ -84,8 +84,8 @@ mosip.kernel.mispid.length = 3
 mosip.kernel.idgenerator.misp.license-key-length = 50
 ## To configure the partner types for which extractors are required. It should be "," separated.
 pmp.bioextractors.required.partner.types = Credential_Partner,Online_Verification_Partner
-mosip.pmp.misp.license.expiry.period.indays = 90
-mosip.pmp.partner.policy.expiry.period.indays = 90
+mosip.pmp.misp.license.expiry.period.indays = 999999
+mosip.pmp.partner.policy.expiry.period.indays = 999999
 pmp.policy.expiry.period.indays = 180
 pmp.policy.schema.url= https://schemas.mosip.io/v1/auth-policy
 


### PR DESCRIPTION
Updated license and policy expiry periods to 999999 days.