### PR TITLE
Change cron job schedules for certificate expiry notifications

### DIFF
--- a/partner-management-default.properties
+++ b/partner-management-default.properties
@@ -333,24 +333,24 @@ logging.level.io.mosip.*=DEBUG
 
 #Cron job schedule
 # This job will create notifications for Root / Intermediate certificate expiry
-mosip.pms.batch.job.root.intermediate.cert.expiry.cron.schedule=0 00 12 * * *
+mosip.pms.batch.job.root.intermediate.cert.expiry.cron.schedule=0 30 4 * * *
 
 # This job will create notifications for Partner certificate expiry
-mosip.pms.batch.job.partner.cert.expiry.cron.schedule=0 45 1 * * *
+mosip.pms.batch.job.partner.cert.expiry.cron.schedule=0 30 4 * * *
 
 #certificate expiry periods in days, when notification are to be triggered
 mosip.pms.batch.job.root.intermediate.cert.expiry.periods=30,15,10,9,7,5,4,3,2,1,0
 mosip.pms.batch.job.partner.cert.expiry.periods=30,15,10,9,7,5,4,3,2,1,0
 
 # This job will create weekly notifications
-mosip.pms.batch.job.weekly.notifications.cron.schedule=0 45 1 * * 2
+mosip.pms.batch.job.weekly.notifications.cron.schedule=0 30 4 * * 3
 
 # This job will create notifications for FTM chip certificate expiry
-mosip.pms.batch.job.ftm.chip.expiry.notifications.cron.schedule=0 45 1 * * *
+mosip.pms.batch.job.ftm.chip.expiry.notifications.cron.schedule=0 30 4 * * *
 # This job will create notifications for SBI expiry
-mosip.pms.batch.job.sbi.expiry.notifications.cron.schedule=0 45 1 * * *
+mosip.pms.batch.job.sbi.expiry.notifications.cron.schedule=0 30 4 * * *
 # This job will create notifications for API key expiry
-mosip.pms.batch.job.api.key.expiry.notifications.cron.schedule=0 45 1 * * *
+mosip.pms.batch.job.api.key.expiry.notifications.cron.schedule=0 30 4 * * *
 
 # This job will auto deactivate expired SBIs
 #mosip.pms.batch.job.sbi.expiry.auto.deactivation.cron.schedule=0 00 10 * * *


### PR DESCRIPTION
Updated cron schedules for various jobs to run at 4:30 AM instead of 1:45 AM.