### PR TITLE
MISP license key expiry notification UTC time set 11:30 AM.

### DIFF
--- a/partner-management-default.properties
+++ b/partner-management-default.properties
@@ -343,7 +343,7 @@ mosip.pms.batch.job.root.intermediate.cert.expiry.cron.schedule=0 30 12 * * *
 mosip.pms.batch.job.partner.cert.expiry.cron.schedule=0 30 12 * * *
 
 # This job will create notifications for Misp certificate expiry
-mosip.pms.batch.job.misp.license.key.expiry.notifications.cron.schedule=0 15 11 * * *
+mosip.pms.batch.job.misp.license.key.expiry.notifications.cron.schedule=0 00 6 * * *
 
 #certificate expiry periods in days, when notification are to be triggered
 mosip.pms.batch.job.root.intermediate.cert.expiry.periods=30,15,10,9,7,5,4,3,2,1,0
@@ -376,7 +376,7 @@ mosip.pms.batch.job.enable.past.notifications.deletion=true
 mosip.pms.batch.job.ftm.chip.cert.expiry.periods=30,15,10,9,8,7,6,5,4,3,2,1,0
 mosip.pms.batch.job.sbi.expiry.periods=30,15,10,9,8,7,6,5,4,3,2,1,0
 mosip.pms.batch.job.api.key.expiry.periods=30,15,10,9,8,7,6,5,4,3,2,1,0
-mosip.pms.batch.job.misp.license.key.expiry.periods=30,15,10,9,8,7,6,5,4,3,2,1,0
+mosip.pms.batch.job.misp.license.key.expiry.periods=40,30,15,10,9,8,7,6,5,4,3,2,1,0
 
 # SSO user session inactivity time in minutes after which the user gets automatically logged out
 mosip.pms.session.inactivity.timer=30


### PR DESCRIPTION
Adjusted MISP license key expiry notification schedule and periods.