### PR TITLE
Clear default value for signature KID prepend

### DIFF
--- a/kernel-default.properties
+++ b/kernel-default.properties
@@ -786,4 +786,4 @@ mosip.kernel.partner.issuer.certificate.duration.years=1
 # Grace period (in days) allowed as an exception to the minimum issuer certificate duration requirement.
 mosip.kernel.partner.issuer.certificate.allowed.grace.duration=30
 
-mosip.kernel.keymanager.signature.kid.prepend=www.mosip.io#
+mosip.kernel.keymanager.signature.kid.prepend=


### PR DESCRIPTION
Removed the default value for 'mosip.kernel.keymanager.signature.kid.prepend'.