### PR TITLE
Reverted to default langaues in application-default.properties

### DIFF
--- a/application-default.properties
+++ b/application-default.properties
@@ -423,7 +423,7 @@ websub.publish.url=${mosip.websub.url}/hub/
 
 mosip.mandatory-languages=eng
 ## Leave blank if no optional langauges
-mosip.optional-languages=ara,fra,tam,hin,kan
+mosip.optional-languages=ara,fra
 mosip.min-languages.count=2
 mosip.max-languages.count=3
 


### PR DESCRIPTION
mosip.optional-languages=ara,fra,tam,hin,kan  removed tam,hin,kan optional language.