### PR TITLE
[DSD-9386]Updated ida and kernel properties

### DIFF
--- a/id-authentication-default.properties
+++ b/id-authentication-default.properties
@@ -10,7 +10,7 @@
 # mosip.kernel.tokenid.uin.salt
 # mpartner.default.auth.secret
 # mosip.kernel.tokenid.partnercode.salt
-# softhsm.ida.pin
+# softhsm.ida.security.pin
 # ida.websub.masterdata.templates.callback.secret
 # ida.websub.masterdata.titles.callback.secret
 

--- a/kernel-default.properties
+++ b/kernel-default.properties
@@ -12,15 +12,12 @@
 # mosip.reg.client.secret
 # mosip.prereg.client.secret
 # softhsm.kernel.security.pin
-# softhsm-security-pin
 # email.smtp.host
 # email.smtp.username
 # email.smtp.secret
 # mosip.kernel.tokenid.uin.salt
 # mosip.kernel.tokenid.partnercode.salt
 # mosip.api.internal.url
-
-softhsm.kernel.security.pin=${softhsm.security.pin}
 
 ## Sync data
 mosip.kernel.syncdata.auth-manager-base-uri=${mosip.kernel.authmanager.url}/v1/authmanager


### PR DESCRIPTION
1.Updated #softhsm.ida.pin to #softhsm.ida.security.pin in id-authentication-default.properties.

2.Removed #softhsm-security-pin and softhsm.kernel.security.pin=${softhsm.security.pin} from kernel-default.properties as these are not in use.