### PR TITLE
MOSIP-44206 Update Kafka configuration for packet validator

### DIFF
--- a/registration-processor-default.properties
+++ b/registration-processor-default.properties
@@ -577,9 +577,9 @@ mosip.regproc.packet.uploader.message.tag.loading.disable=true
 
 #packet-validator-stage
 mosip.regproc.packet.validator.eventbus.kafka.commit.type=batch
-mosip.regproc.packet.validator.eventbus.kafka.max.poll.records=12
+mosip.regproc.packet.validator.eventbus.kafka.max.poll.records=16
 mosip.regproc.packet.validator.eventbus.kafka.max.poll.interval=900000
-mosip.regproc.packet.validator.eventbus.kafka.poll.frequency=90
+mosip.regproc.packet.validator.eventbus.kafka.poll.frequency=60000
 mosip.regproc.packet.validator.eventbus.kafka.group.id=packet-validator-stage
 mosip.regproc.packet.validator.message.expiry-time-limit=${mosip.regproc.common.stage.message.expiry-time-limit}
 mosip.regproc.packet.validator.server.port=8088


### PR DESCRIPTION
Increased max poll records and adjusted poll frequency for Kafka.