### PR TITLE
MOSIP-40013: revert virtual thread configuration for tomcat

### DIFF
--- a/packet-manager-default.properties
+++ b/packet-manager-default.properties
@@ -70,5 +70,3 @@ redis.cache.min.idle=50
 redis.cache.num.tests.per.eviction.run=50
 redis.cache.eviction.run.interval=120000
 redis.cache.min.evictable.idle.time=300000
-# Virtual threads for Tomcat request handling (Spring Boot 3.2)
-spring.threads.virtual.enabled=true


### PR DESCRIPTION
Re-enable the configuration for minimum evictable idle time in Redis cache and virtual threads for Tomcat request handling.