### PR TITLE
MOSIP-40013: Update socket timeout to 25000 ms

### DIFF
--- a/registration-processor-default.properties
+++ b/registration-processor-default.properties
@@ -1201,7 +1201,7 @@ mosip.kernel.http.selftoken.restTemplate.max-connection-per-route=150
 # Rest template properties for total max connections
 mosip.kernel.http.selftoken.restTemplate.total-max-connections=600
 # Rest template property for timeout in case response is not being received post connection to the server. This is an experimental property.During performance tuning, value 30000 is considered.
-mosip.kernel.http.selftoken.restTemplate.socket-timeout=10000
+mosip.kernel.http.selftoken.restTemplate.socket-timeout=25000
 
 # Thread pool used for quality classification
 # The pool size must be calculated as : workerThread * segments.


### PR DESCRIPTION
Increased socket timeout for selftoken restTemplate.