### PR TITLE
MOSIP-44206 Remove Tomcat thread pool settings

### DIFF
--- a/packet-manager-default.properties
+++ b/packet-manager-default.properties
@@ -70,14 +70,7 @@ redis.cache.min.idle=50
 redis.cache.num.tests.per.eviction.run=50
 redis.cache.eviction.run.interval=120000
 redis.cache.min.evictable.idle.time=300000
-
-# Increase Tomcat thread pool — packet-manager is I/O-heavy (S3 + HTTP decrypt/verify).                                                                                                                   
-# Default 200 threads fills up fast when multiple services call concurrently and each                                                                                                              
-# request blocks for S3 round-trips. Virtual threads (JDK 21) handle the S3 waits by                                                                                                               
-# unmounting; OS threads here only need to cover requests actively using the CPU.                                                                                                                         
-server.tomcat.threads.max=400                                                                                                                                                                             
-server.tomcat.threads.min-spare=50                                                                                                                                                                        
-server.tomcat.accept-count=200                                                                                                                                                                            
+                                                                                                                                                                           
 #disabling health check so that client doesnt try to load properties from sprint config server every                                                                                                      
 # 5 minutes (should not  be done in production)                                                                                                                                                           
 health.config.enabled=false


### PR DESCRIPTION
Removed Tomcat thread pool configuration to optimize resource usage.