### PR TITLE
[MOSIP-44544]: Added regex for individualId validation qa21

### DIFF
--- a/id-repository-default.properties
+++ b/id-repository-default.properties
@@ -511,3 +511,6 @@ mosip.idrepo.idvid.metadata.version=1.0
 mosip.idrepo.idvid.metadata.id=mosip.idrepo.idvid.metadata
 
 mosip.role.idrepo.identity.postSearchIdVidMetadata=RESIDENT,ID_REPOSITORY,REGISTRATION_PROCESSOR
+
+# Regex for individualId validation: ensures the string is alphanumeric or numeric (letters and digits)
+mosip.individualId.validation.regex=^(?=.*\\d)[a-zA-Z0-9]+$


### PR DESCRIPTION
Add regex for individualId validation to ensure it is alphanumeric or numeric.