### PR TITLE
MOSIP-36428: Enable specific RNG provider for key generation

### DIFF
--- a/kernel-default.properties
+++ b/kernel-default.properties
@@ -787,3 +787,7 @@ mosip.kernel.partner.issuer.certificate.allowed.grace.duration=30
 
 # Prefix to prepend to the JWT 'kid'; supports static values or PAYLOAD_ISSUER to derive prefix from the payload 'iss' field.
 mosip.kernel.keymanager.signature.kid.prepend=
+
+# Enable this property to use a specific Security Provider for SecureRandom (RNG) during key generation.
+# Disable if you do not want to use a specific RNG provider.
+mosip.kernel.keygenerator.rng.provider.enable=false


### PR DESCRIPTION
Add configuration for Security Provider in key generation