### PR TITLE
[MOSIP-44356] Changed camel for sending the packet from the abis-middleware to biodedupe

### DIFF
--- a/registration-processor-camel-routes-new-default.xml
+++ b/registration-processor-camel-routes-new-default.xml
@@ -423,7 +423,7 @@
             <to uri="workflow-cmd://anonymous-profile" />
          </when>
          <otherwise>
-            <to uri="eventbus://abis-handler-bus-in" />
+            <to uri="eventbus://bio-dedupe-bus-in" />
          </otherwise>
       </choice>
    </route>


### PR DESCRIPTION
[MOSIP-44356] Changed camel for sending the packet from the abis-middleware to biodedupe

[MOSIP-44356]: https://mosip.atlassian.net/browse/MOSIP-44356?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ