### PR TITLE
[DSD-10082]Update mock-abis-default.properties to accept duplicates in the registration.

### DIFF
--- a/mock-abis-default.properties
+++ b/mock-abis-default.properties
@@ -7,7 +7,7 @@ spring.application.name=mock-abis-service
 management.endpoint.health.show-details=always
 management.endpoits.web.exposure.include=info,health,refresh
 server.port=8081
-abis.return.duplicate=true
+abis.return.duplicate=false
 #iam adapter
 auth.server.admin.issuer.uri=${keycloak.external.url}/auth/realms/
 mosip.iam.adapter.appid=regproc


### PR DESCRIPTION
Updating mock-abis-default.properties to accept duplicates in the registration client(ABIS)