### PR TITLE
[MOSIP-40013] Removed 'workflow-cmd://anonymous-profile' while sending to biometric extraction

### DIFF
--- a/registration-processor-camel-routes-new-default.xml
+++ b/registration-processor-camel-routes-new-default.xml
@@ -471,7 +471,6 @@
          </when>
          <otherwise>
             <to uri="eventbus://biometric-extraction-bus-in" />
-            <to uri="workflow-cmd://anonymous-profile" />
          </otherwise>
       </choice>
    </route>


### PR DESCRIPTION
[MOSIP-40013] Removed 'workflow-cmd://anonymous-profile' while sending to biometric extraction

[MOSIP-40013]: https://mosip.atlassian.net/browse/MOSIP-40013?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ