### PR TITLE
MOSIP-44615 Change minimum validity for Partner CA certificate upload

### DIFF
--- a/kernel-default.properties
+++ b/kernel-default.properties
@@ -777,7 +777,7 @@ spring.datasource.hikari.maximum-pool-size=30
 spring.datasource.hikari.minimum-idle=10
 
 # Minimum validity (in months) required for uploading a Partner CA certificate.
-mosip.kernel.partner.cacertificate.upload.minimumvalidity.month=12
+mosip.kernel.partner.cacertificate.upload.minimumvalidity.month=24
 
 # Minimum validity duration (in years) required for Partner Certificates at the time of upload.
 mosip.kernel.partner.issuer.certificate.duration.years=1


### PR DESCRIPTION
Updated minimum validity for uploading Partner CA certificates from 12 months to 24 months.