### PR TITLE
 [MOSIP-44198] Adding 1 sec delay to ABIS response.

### DIFF
--- a/mock-abis-default.properties
+++ b/mock-abis-default.properties
@@ -19,3 +19,4 @@ mosip.kernel.auth.appids.realm.map={abis:'mosip'}
 #iam adapter disable local end points
 mosip.service.end-points=/**/*
 mosip.service.exclude.auth.allowed.method=GET,POST,DELETE
+registration.processor.abis.response.delay

--- a/mock-abis-default.properties
+++ b/mock-abis-default.properties
@@ -19,4 +19,4 @@ mosip.kernel.auth.appids.realm.map={abis:'mosip'}
 #iam adapter disable local end points
 mosip.service.end-points=/**/*
 mosip.service.exclude.auth.allowed.method=GET,POST,DELETE
-registration.processor.abis.response.delay
+registration.processor.abis.response.delay=1


### PR DESCRIPTION
[MOSIP-44198] Adding 1 sec delay to ABIS response.

[MOSIP-44198]: https://mosip.atlassian.net/browse/MOSIP-44198?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ