### PR TITLE
MOSIP-44206 Modify access log pattern for timeTaken format

### DIFF
--- a/application-default.properties
+++ b/application-default.properties
@@ -416,7 +416,7 @@ server.tomcat.accesslog.prefix=stdout
 server.tomcat.accesslog.buffered=false
 server.tomcat.accesslog.suffix=
 server.tomcat.accesslog.file-date-format=
-server.tomcat.accesslog.pattern={"@timestamp":"%{yyyy-MM-dd'T'HH:mm:ss.SSS'Z'}t","level":"ACCESS","level_value":70000,"traceId":"%{X-B3-TraceId}i","statusCode":%s,"req.requestURI":"%U","bytesSent":%b,"timeTaken":%T,"appName":"${spring.application.name}","req.userAgent":"%{User-Agent}i","req.xForwardedFor":"%{X-Forwarded-For}i","req.referer":"%{Referer}i","req.method":"%m","req.remoteHost":"%a"}
+server.tomcat.accesslog.pattern={"@timestamp":"%{yyyy-MM-dd'T'HH:mm:ss.SSS'Z'}t","level":"ACCESS","level_value":70000,"traceId":"%{X-B3-TraceId}i","statusCode":%s,"req.requestURI":"%U","bytesSent":%b,"timeTaken":%D,"appName":"${spring.application.name}","req.userAgent":"%{User-Agent}i","req.xForwardedFor":"%{X-Forwarded-For}i","req.referer":"%{Referer}i","req.method":"%m","req.remoteHost":"%a"}
 server.tomcat.accesslog.className=io.mosip.kernel.core.logger.config.SleuthValve
 
 ## Websub (internal url)


### PR DESCRIPTION
Updated the access log pattern to use timeTaken in milliseconds.