### PR TITLE
MOSIP-44206 Change credential status update job delay to 2 hours

### DIFF
--- a/id-repository-default.properties
+++ b/id-repository-default.properties
@@ -199,7 +199,7 @@ mosip.idrepo.credential.cancel-request.rest.timeout=100
 
 ## Credential status job
 # Fixed delay time after which job will be triggered again to process the created/updated credential details.
-mosip.idrepo.credential-status-update-job.fixed-delay-in-ms=10000
+mosip.idrepo.credential-status-update-job.fixed-delay-in-ms=7200000
 
 # Dummy partner id used to create a credential request record in credential_request_status.
 # Credential won't be issued for the below provided. id-repository-credential-feeder will utilize


### PR DESCRIPTION
Updated the fixed delay for the credential status update job to 2 hours.