### PR TITLE
MOSIP-44206 Decrease Redis cache time-to-live to 20 minutes

### DIFF
--- a/packet-manager-default.properties
+++ b/packet-manager-default.properties
@@ -51,7 +51,7 @@ spring.redis.host=172.31.4.76
 spring.redis.port=6379
 management.health.redis.enabled=false
 spring.redis.password=mosip123
-spring.cache.redis.time-to-live=1800000
+spring.cache.redis.time-to-live=1200000
 mosip.kernel.http.selftoken.restTemplate.max-connection-per-route=70
 mosip.kernel.http.selftoken.restTemplate.total-max-connections=500
 


### PR DESCRIPTION
Reduced Redis cache time-to-live from 30 minutes to 20 minutes.