### PR TITLE
Updated for 1.2 IDA standalone

### DIFF
--- a/sandbox/kernel-lts.properties
+++ b/sandbox/kernel-lts.properties
@@ -148,7 +148,7 @@ kernel.prid.revoke-scheduler-days_of_week=*
 ## Database properties
 # Database hostname below is assuming postgres is running inside cluster in 'postgres' namespace
 # If database is external to production, provide the DNS or ip of the host and port 
-mosip.kernel.database.hostname=postgres-postgresql.postgres
+mosip.kernel.database.hostname=postgres-postgresql.postgres.svc.cluster.local
 mosip.kernel.database.port=5432
 
 javax.persistence.jdbc.driver=org.postgresql.Driver


### PR DESCRIPTION
changes made for deploying 1.2 ida in separate cluster with backend qa3-1.1.5