### PR TITLE
#573: disable the rng provider

### DIFF
--- a/kernel-default.properties
+++ b/kernel-default.properties
@@ -807,3 +807,6 @@ keymanager.hikari.connectionTimeout=10000
 keymanager.hikari.idleTimeout=600000
 keymanager.hikari.maximumPoolSize=40
 mosip.kernel.uin.health.checker.time.ms=6000
+
+#disable rng provider while generating the SecureRandom
+mosip.kernel.keygenerator.rng.provider.enable=false


### PR DESCRIPTION
Added configuration to disable RNG provider for SecureRandom generation.