### PR TITLE
#1962: Disable RNG provider for SecureRandom generation

### DIFF
--- a/kernel-default.properties
+++ b/kernel-default.properties
@@ -787,3 +787,6 @@ mosip.kernel.partner.issuer.certificate.allowed.grace.duration=30
 
 # Prefix to prepend to the JWT 'kid'; supports static values or PAYLOAD_ISSUER to derive prefix from the payload 'iss' field.
 mosip.kernel.keymanager.signature.kid.prepend=
+
+#disable rng provider while generating the SecureRandom
+mosip.kernel.keygenerator.rng.provider.enable=false


### PR DESCRIPTION
https://github.com/mosip/mosip-functional-tests/issues/1962