### PR TITLE
MOSIP-44737 Changed deprecated api to use new api

### DIFF
--- a/resident-default.properties
+++ b/resident-default.properties
@@ -250,9 +250,9 @@ resident.notification.message=Notification has been sent to the provided contact
 ## Partner manager service URLs
 PMS_PARTNER_MANAGER=${mosip.pms.partnermanager.url}/v1/partnermanager
 POLICY_REQ_URL=${PMS_PARTNER_MANAGER}/partners/{partnerId}/credentialtype/{credentialType}/policies
+PARTNER_API_URL_V2=${PMS_PARTNER_MANAGER}/admin-partners/v2
 PARTNER_API_URL=${PMS_PARTNER_MANAGER}/admin-partners/v2
-PARTNER_DETAILS_NEW_URL=${PMS_PARTNER_MANAGER}/partners/v2
-mosip.pms.pmp.partner.rest.uri=${PMS_PARTNER_MANAGER}/partners?partnerType=${mosip.ida.partner.type}
+resident.partner.list.page.size=100
 
 ## Reg-proc service calls
 REGPROCPRINT=http://regproc-group7.regproc/registrationprocessor/v1/print/uincard

--- a/resident-default.properties
+++ b/resident-default.properties
@@ -250,6 +250,7 @@ resident.notification.message=Notification has been sent to the provided contact
 ## Partner manager service URLs
 PMS_PARTNER_MANAGER=${mosip.pms.partnermanager.url}/v1/partnermanager
 POLICY_REQ_URL=${PMS_PARTNER_MANAGER}/partners/{partnerId}/credentialtype/{credentialType}/policies
+PARTNER_API_URL_V2=${PMS_PARTNER_MANAGER}/admin-partners/v2
 PARTNER_API_URL=${PMS_PARTNER_MANAGER}/admin-partners/v2
 resident.partner.list.page.size=10
 

--- a/resident-default.properties
+++ b/resident-default.properties
@@ -250,7 +250,6 @@ resident.notification.message=Notification has been sent to the provided contact
 ## Partner manager service URLs
 PMS_PARTNER_MANAGER=${mosip.pms.partnermanager.url}/v1/partnermanager
 POLICY_REQ_URL=${PMS_PARTNER_MANAGER}/partners/{partnerId}/credentialtype/{credentialType}/policies
-PARTNER_API_URL_V2=${PMS_PARTNER_MANAGER}/admin-partners/v2
 PARTNER_API_URL=${PMS_PARTNER_MANAGER}/admin-partners/v2
 resident.partner.list.page.size=10
 

--- a/resident-default.properties
+++ b/resident-default.properties
@@ -252,7 +252,7 @@ PMS_PARTNER_MANAGER=${mosip.pms.partnermanager.url}/v1/partnermanager
 POLICY_REQ_URL=${PMS_PARTNER_MANAGER}/partners/{partnerId}/credentialtype/{credentialType}/policies
 PARTNER_API_URL_V2=${PMS_PARTNER_MANAGER}/admin-partners/v2
 PARTNER_API_URL=${PMS_PARTNER_MANAGER}/admin-partners/v2
-resident.partner.list.page.size=100
+resident.partner.list.page.size=10
 
 ## Reg-proc service calls
 REGPROCPRINT=http://regproc-group7.regproc/registrationprocessor/v1/print/uincard
@@ -1116,6 +1116,7 @@ resident.cache.expiry.time.millisec.getImmediateChildrenByLocCode=86400000
 resident.cache.expiry.time.millisec.getLocationHierarchyLevels=86400000
 resident.cache.expiry.time.millisec.getAllDynamicFieldByName=86400000
 resident.cache.expiry.time.millisec.getNameValueFromIdentityMapping=86400000
+resident.cache.expiry.time.millisec.partnerByIssuerCache=86400000
 
 # Separators
 # Usage: resident.attribute.separator.<attribute>=<separator string>

--- a/resident-default.properties
+++ b/resident-default.properties
@@ -250,7 +250,7 @@ resident.notification.message=Notification has been sent to the provided contact
 ## Partner manager service URLs
 PMS_PARTNER_MANAGER=${mosip.pms.partnermanager.url}/v1/partnermanager
 POLICY_REQ_URL=${PMS_PARTNER_MANAGER}/partners/{partnerId}/credentialtype/{credentialType}/policies
-PARTNER_API_URL_V2=${PMS_PARTNER_MANAGER}/admin-partners/v2
+PARTNER_BY_PARTNER_ID_API_URL=${PMS_PARTNER_MANAGER}/admin-partners/v2
 PARTNER_API_URL=${PMS_PARTNER_MANAGER}/admin-partners/v2
 resident.partner.list.page.size=10
 

--- a/resident-default.properties
+++ b/resident-default.properties
@@ -250,7 +250,7 @@ resident.notification.message=Notification has been sent to the provided contact
 ## Partner manager service URLs
 PMS_PARTNER_MANAGER=${mosip.pms.partnermanager.url}/v1/partnermanager
 POLICY_REQ_URL=${PMS_PARTNER_MANAGER}/partners/{partnerId}/credentialtype/{credentialType}/policies
-PARTNER_API_URL=${PMS_PARTNER_MANAGER}/partners
+PARTNER_API_URL=${PMS_PARTNER_MANAGER}/admin-partners/v2
 PARTNER_DETAILS_NEW_URL=${PMS_PARTNER_MANAGER}/partners/v2
 mosip.pms.pmp.partner.rest.uri=${PMS_PARTNER_MANAGER}/partners?partnerType=${mosip.ida.partner.type}
 

--- a/resident-default.properties
+++ b/resident-default.properties
@@ -250,8 +250,8 @@ resident.notification.message=Notification has been sent to the provided contact
 ## Partner manager service URLs
 PMS_PARTNER_MANAGER=${mosip.pms.partnermanager.url}/v1/partnermanager
 POLICY_REQ_URL=${PMS_PARTNER_MANAGER}/partners/{partnerId}/credentialtype/{credentialType}/policies
-PARTNER_BY_PARTNER_ID_API_URL=${PMS_PARTNER_MANAGER}/admin-partners/v2
 PARTNER_API_URL=${PMS_PARTNER_MANAGER}/admin-partners/v2
+PARTNER_BY_PARTNER_ID_API_URL=${PMS_PARTNER_MANAGER}/admin-partners/v2
 resident.partner.list.page.size=10
 
 ## Reg-proc service calls


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `PARTNER_BY_PARTNER_ID_API_URL` and introduced a configurable partner list page size (`resident.partner.list.page.size`) set to **10**.

* **Changes**
  * Updated partner API usage to the newer `/admin-partners/v2` endpoints by repointing the main `PARTNER_API_URL`.
  * Removed legacy partner endpoint properties (`PARTNER_DETAILS_NEW_URL` and the older partner REST URI).
  * Extended partner-by-issuer cache expiration by setting `resident.cache.expiry.time.millisec.partnerByIssuerCache` to **86400000** milliseconds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->