### PR TITLE
MOSIP-44279 Add id_token claims to login flow configuration

### DIFF
--- a/resident-default.properties
+++ b/resident-default.properties
@@ -416,7 +416,7 @@ mosip.iam.module.redirecturi=${mosip.api.internal.url}/resident/v1/login-redirec
 mosip.iam.module.login_flow.name=authorization_code
 #mosip.iam.module.login_flow.scope=cls
 mosip.iam.module.login_flow.scope=openid profile Manage-Identity-Data Manage-VID Manage-Authentication Manage-Service-Requests Manage-Credentials
-mosip.iam.module.login_flow.claims={"userinfo":{"name":{"essential":true},"picture":{"essential":true},"email":{"essential":true},"phone_number":{"essential":true},"individual_id":{"essential":true}}}
+mosip.iam.module.login_flow.claims={"userinfo":{"name":{"essential":true},"picture":{"essential":true},"email":{"essential":true},"phone_number":{"essential":true},"individual_id":{"essential":true}},"id_token":{}}
 mosip.iam.module.login_flow.response_type=code
 mosip.iam.module.admin_realm_id=mosip
 


### PR DESCRIPTION
## Add `"id_token":{}` to `mosip.iam.module.login_flow.claims` (required after eSignet 1.4.1 → 1.6.2 upgrade)

### Change

```properties
# Before
mosip.iam.module.login_flow.claims={"userinfo":{"name":{"essential":true},"picture":{"essential":true},"email":{"essential":true},"phone_number":{"essential":true},"individual_id":{"essential":true}}}

# After
mosip.iam.module.login_flow.claims={"userinfo":{"name":{"essential":true},"picture":{"essential":true},"email":{"essential":true},"phone_number":{"essential":true},"individual_id":{"essential":true}},"id_token":{}}
```

### Problem

After upgrading eSignet from 1.4.1 to 1.6.2, the Resident Portal login flow breaks at the first step. `POST /v1/esignet/authorization/v3/oauth-details` fails with:

```json
{"errors":[{"errorCode":"invalid_claim","errorMessage":"request.claims: invalid_claim"}]}
```

eSignet pod log:

```
ERROR io.mosip.esignet.core.validator.ClaimsSchemaValidator - Validation failed for claims: [$.id_token: null found, object expected]
```

### Root cause

eSignet 1.4.1 validated the `claims` request parameter with plain DTO/bean validation, where an absent `id_token` member was simply `null` and accepted.

eSignet 1.6.x introduced JSON-schema-based validation of the `claims` parameter (`ClaimsSchemaValidator`, backing OpenID Connect Identity Assurance / verified claims support). The validator works as follows:

1. The incoming `claims` JSON is deserialized into `ClaimsV2` (fields `userinfo` and `id_token`). When the RP omits `id_token`, the field is `null`.
2. The validator re-serializes the DTO with `objectMapper.valueToTree(claims)`, which **includes null fields**, producing `{"userinfo":{...},"id_token":null}`.
3. That tree is validated against `claims_request_schema.json` (configured via `mosip.esignet.claims.schema.url`), where `id_token` is declared strictly as `"type": "object"` with no `null` alternative.
4. `id_token: null` therefore fails schema validation and the whole oauth-details request is rejected with `invalid_claim`.

Per OIDC Core §5.5 the `id_token` member of the `claims` parameter is optional, so omitting it is spec-compliant — this is a regression in eSignet's validation, not a Resident Services defect. Until it is fixed upstream (schema should allow `null`, or the validator should serialize with `NON_NULL` inclusion), every RP calling eSignet 1.6.x must send an explicit `id_token` member.

### Why `"id_token":{}` works

An empty object satisfies the schema (`"type":"object"`, `additionalProperties: true`, no `minProperties`), deserializes into an empty map in `ClaimsV2`, and requests no id_token claims — so runtime behavior of the login flow is unchanged. It only makes the previously-implicit "no id_token claims requested" explicit in a form the 1.6.2 validator accepts.

### Impact

Without this change, Resident Portal login via eSignet 1.6.2 fails for all users at the oauth-details step. No behavioral change otherwise: same claims are requested in `userinfo`, no claims are requested in `id_token`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated OIDC login claim handling to explicitly include ID token claims, improving compatibility with identity providers during sign-in.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->