### PR TITLE
Comment out response delay configuration

### DIFF
--- a/mock-abis-default.properties
+++ b/mock-abis-default.properties
@@ -20,4 +20,4 @@ mosip.kernel.auth.appids.realm.map={abis:'mosip'}
 mosip.service.end-points=/**/*
 mosip.service.exclude.auth.allowed.method=GET,POST,DELETE
 #registration.processor.abis.response.delay.unit=milliseconds
-registration.processor.abis.response.delay=30
+#registration.processor.abis.response.delay=30


### PR DESCRIPTION
Comment out the registration.processor.abis.response.delay property.